### PR TITLE
✨ Add Additional Meta Data to Compliance Report Page

### DIFF
--- a/app/projects/repository_standards/services/repository_compliance_service.py
+++ b/app/projects/repository_standards/services/repository_compliance_service.py
@@ -28,11 +28,13 @@ class RepositoryComplianceReportView:
         compliance_status: str,
         authorative_owner: str | None,
         checks: List[RepositoryComplianceCheck],
+        description: str = "",
     ):
         self.name = name
         self.compliance_status = compliance_status
         self.authorative_owner = authorative_owner
         self.checks = checks
+        self.description = description
 
 
 class RepositoryComplianceService:
@@ -117,7 +119,7 @@ class RepositoryComplianceService:
                 name="Has an Authorative Owner",
                 status="pass" if len(authorative_owner) > 0 else "fail",
                 required=False,
-                description="Prevents orphaned repositories by having a easily identifiable owner",
+                description="Prevents orphaned repositories by having an easily identifiable owner",
             ),
             RepositoryComplianceCheck(
                 name="License is MIT",
@@ -148,6 +150,7 @@ class RepositoryComplianceService:
             if len(authorative_owner) > 0
             else None,
             checks=checks,
+            description=asset.data.get("description", ""),
         )
 
     def get_all_repositories(self) -> List[RepositoryComplianceReportView]:

--- a/app/templates/projects/repository_standards/pages/home.html
+++ b/app/templates/projects/repository_standards/pages/home.html
@@ -67,13 +67,12 @@
       <tbody class="govuk-table__body">
         {% for repository in repositories %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><a href="https://github.com/ministryofjustice/{{ repository.name }}" rel="noreferrer noopener" target="_blank" class="govuk-link">{{ repository.name }}</a></td>
+          <td class="govuk-table__cell">{{ repository.name }}</td>
           <td class="govuk-table__cell">
             <img src="/assets/images/{{ repository.compliance_status }}-badge.svg"  alt="{{ repository["compliance_status"] }}" />
           </td>
           <td class="govuk-table__cell">{{ repository.authorative_owner }}</td>
-          <td class="govuk-table__cell"><a href="https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/{{ repository.name }}" rel="noreferrer noopener" target="_blank" class="govuk-link">View Compliace Report</a></td>
-          <td class="govuk-table__cell"><a href="/repository-standards/{{ repository.name }}/compliance-report" rel="noreferrer noopener" class="govuk-link">View New Compliace Report</a></td>
+          <td class="govuk-table__cell"><a href="/repository-standards/{{ repository.name }}/compliance-report" rel="noreferrer noopener" class="govuk-link">View Compliance Report</a></td>
         </tr>
         {% endfor %}
       </tbody>

--- a/app/templates/projects/repository_standards/pages/repository_compliance_report.html
+++ b/app/templates/projects/repository_standards/pages/repository_compliance_report.html
@@ -23,7 +23,33 @@
 
 
   <h1 class="govuk-heading-xl">Compliance Report - {{ repository.name }}</h1>
-  <img src="/repository-standards/api/{{ repository.name }}/badge"  alt="{{ repository.compliance_status }}" />
+
+  <section class="govuk-summary-list govuk-!-margin-bottom-6">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Owner</dt>
+      <dd class="govuk-summary-list__value">{{ repository.authorative_owner }}</dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Description</dt>
+      <dd class="govuk-summary-list__value">{{ repository.description }}</dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Compliance Badge</dt>
+      <dd class="govuk-summary-list__value"><img src="/repository-standards/api/{{ repository.name }}/badge"  alt="{{ repository.compliance_status }}" /></dd>
+    </div>
+
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">References</dt>
+      <dd class="govuk-summary-list__value">
+        <a href="https://github.com/ministryofjustice/{{ repository.name }}" rel="noreferrer noopener" target="_blank" class="govuk-link">View Repository on GitHub</a>
+        <br />
+        <a href="https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/{{ repository.name }}" rel="noreferrer noopener" target="_blank" class="govuk-link">View Legacy Compliance Report</a>
+      </dd>
+    </div>
+  </section>
 
   <section>
     <h2 class="govuk-heading-l">Required Checks</h1>
@@ -41,7 +67,7 @@
       <tbody class="govuk-table__body">
         {% for check in repository.checks if check.required %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{ check.name }}<p class="govuk-body-s">{{ check.description }}</p></td>
+          <td class="govuk-table__cell govuk-!-font-weight-bold">{{ check.name }}<p class="govuk-body-s">{{ check.description }}</p></td>
           <td class="govuk-table__cell">
             <span class="
                         {% if check.status == "fail" %} govuk-tag govuk-tag--red
@@ -74,7 +100,7 @@
       <tbody class="govuk-table__body">
         {% for check in repository.checks if not check.required %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{ check.name }}<p class="govuk-body-s">{{ check.description }}</p></td>
+          <td class="govuk-table__cell govuk-!-font-weight-bold">{{ check.name }}<p class="govuk-body-s">{{ check.description }}</p></td>
           <td class="govuk-table__cell">
             <span class="
                         {% if check.status == "fail" %} govuk-tag govuk-tag--red


### PR DESCRIPTION
## 👀 Purpose

- To make the report page feel more complete by adding useful information and links

## ♻️ What's changed

- Added descriptions, owner, link to legacy report and link to GitHub Repo
- Fixed some content issues