### PR TITLE
🐘 Bump Postgres to match Cloud Platform

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   database:
-    image: public.ecr.aws/docker/library/postgres:14-alpine
+    image: public.ecr.aws/docker/library/postgres:17-alpine
     environment:
       - POSTGRES_DB=admin
       - POSTGRES_USER=admin


### PR DESCRIPTION
## Proposed Changes

- Bumps Postgres to 17 to match Cloud Platform deployment 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>