### PR TITLE
✨ Add Legacy Repository Reports Endpoints

### DIFF
--- a/app/projects/repository_standards/routes/deprecated.py
+++ b/app/projects/repository_standards/routes/deprecated.py
@@ -1,0 +1,61 @@
+import logging
+
+from flask import Blueprint, redirect
+
+from app.projects.repository_standards.services.repository_compliance_service import (
+    get_repository_compliance_service,
+)
+
+logger = logging.getLogger(__name__)
+
+repository_standards_deprecated = Blueprint("repository_standards_deprecated", __name__)
+
+
+@repository_standards_deprecated.route(
+    "/api/v1/compliant_public_repositories/<repository_name>",
+    methods=["GET"],
+)
+@repository_standards_deprecated.route(
+    "/api/v1/compliant_public_repositories/endpoint/<repository_name>",
+    methods=["GET"],
+)
+def deprecated_reports_badge_api(repository_name: str):
+    repository_compliance_service = get_repository_compliance_service()
+
+    repository = repository_compliance_service.get_repository_by_name(repository_name)
+
+    return {
+        "color": "005ea5",
+        "label": "MoJ Compliant",
+        "labelColor": "231f20",
+        "message": repository.compliance_status.capitalize()
+        if repository
+        else "Not Found",
+        "schemaVersion": 1,
+        "style": "for-the-badge",
+    }
+
+
+@repository_standards_deprecated.route(
+    "/public-report/<repository_name>",
+    methods=["GET"],
+)
+def deprecated_report_page_url(repository_name: str):
+    return redirect(
+        f"/repository-standards/{repository_name}/compliance-report", code=302
+    )
+
+
+@repository_standards_deprecated.route(
+    "/github_repositories",
+    methods=["GET"],
+)
+def deprecated_reports_homepage():
+    return {
+        "color": "005ea5",
+        "label": "MoJ Compliant",
+        "labelColor": "231f20",
+        "message": "See https://github-community.service.justice.gov.uk/repository-standards/ or #github-community",
+        "schemaVersion": 1,
+        "style": "for-the-badge",
+    }

--- a/app/projects/repository_standards/services/repository_compliance_service.py
+++ b/app/projects/repository_standards/services/repository_compliance_service.py
@@ -62,7 +62,7 @@ class RepositoryComplianceService:
                 description="Imporves organisational security by scanning and reporting secrets.",
             ),
             RepositoryComplianceCheck(
-                name="Push Proection Enabled",
+                name="Push Protection Enabled",
                 status="pass"
                 if asset.data.get("security_and_analysis_push_protection_status")
                 == "enabled"
@@ -119,7 +119,7 @@ class RepositoryComplianceService:
                 name="Has an Authorative Owner",
                 status="pass" if len(authorative_owner) > 0 else "fail",
                 required=False,
-                description="Prevents orphaned repositories by having an easily identifiable owner",
+                description="Prevents orphaned repositories by having an easily identifiable owner.",
             ),
             RepositoryComplianceCheck(
                 name="License is MIT",
@@ -174,50 +174,22 @@ class RepositoryComplianceService:
 
         return repository_compliance_report
 
-    def get_repository_compliance_badge_by_name_as_svg_bytes(
-        self, repository_name: str
-    ) -> bytes:
-        repository = self.get_repository_by_name(repository_name)
-        STATUS_COLORS = {
-            "pass": "005ea5",  # MoJ blue
-            "fail": "cc0000",  # Red
-            "unknown": "808080",  # Grey
-        }
-
-        logo = "iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAABmJLR0QA/wD/AP+gvaeTAAAHJElEQVRYhe2YeYyW1RWHnzuMCzCIglBQlhSV2gICKlHiUhVBEAsxGqmVxCUUIV1i61YxadEoal1SWttUaKJNWrQUsRRc6tLGNlCXWGyoUkCJ4uCCSCOiwlTm6R/nfPjyMeDY8lfjSSZz3/fee87vnnPu75z3g8/kM2mfqMPVH6mf35t6G/ZgcJ/836Gdug4FjgO67UFn70+FDmjcw9xZaiegWX29lLLmE3QV4Glg8x7WbFfHlFIebS/ANj2oDgX+CXwA9AMubmPNvuqX1SnqKGAT0BFoVE9UL1RH7nSCUjYAL6rntBdg2Q3AgcAo4HDgXeBAoC+wrZQyWS3AWcDSUsomtSswEtgXaAGWlVI2q32BI0spj9XpPww4EVic88vaC7iq5Hz1BvVf6v3qe+rb6ji1p3pWrmtQG9VD1Jn5br+Knmm70T9MfUh9JaPQZu7uLsR9gEsJb3QF9gOagO7AuUTom1LpCcAkoCcwQj0VmJregzaipA4GphNe7w/MBearB7QLYCmlGdiWSm4CfplTHwBDgPHAFmB+Ah8N9AE6EGkxHLhaHU2kRhXc+cByYCqROs05NQq4oR7Lnm5xE9AL+GYC2gZ0Jmjk8VLKO+pE4HvAyYRnOwOH5N7NhMd/WKf3beApYBWwAdgHuCLn+tatbRtgJv1awhtd838LEeq30/A7wN+AwcBt+bwpD9AdOAkYVkpZXtVdSnlc7QI8BlwOXFmZ3oXkdxfidwmPrQXeA+4GuuT08QSdALxC3OYNhBe/TtzON4EziZBXD36o+q082BxgQuqvyYL6wtBY2TyEyJ2DgAXAzcC1+Xxw3RlGqiuJ6vE6QS9VGZ/7H02DDwAvELTyMDAxbfQBvggMAAYR9LR9J2cluH7AmnzuBowFFhLJ/wi7yiJgGXBLPq8A7idy9kPgvAQPcC9wERHSVcDtCfYj4E7gr8BRqWMjcXmeB+4tpbyG2kG9Sl2tPqF2Uick8B+7szyfvDhR3Z7vvq/2yqpynnqNeoY6v7LvevUU9QN1fZ3OTeppWZmeyzRoVu+rhbaHOledmoQ7LRd3SzBVeUo9Wf1DPs9X90/jX8m/e9Rn1Mnqi7nuXXW5+rK6oU7n64mjszovxyvVh9WeDcTVnl5KmQNcCMwvpbQA1xE8VZXhwDXAz4FWIkfnAlcBAwl6+SjD2wTcmPtagZnAEuA3dTp7qyNKKe8DW9UeBCeuBsbsWKVOUPvn+MRKCLeq16lXqLPVFvXb6r25dlaGdUx6cITaJ8fnpo5WI4Wuzcjcqn5Y8eI/1F+n3XvUA1N3v4ZamIEtpZRX1Y6Z/DUK2g84GrgHuDqTehpBCYend94jbnJ34DDgNGArQT9bict3Y3p1ZCnlSoLQb0sbgwjCXpY2blc7llLW1UAMI3o5CD4bmuOlwHaC6xakgZ4Z+ibgSxnOgcAI4uavI27jEII7909dL5VSrimlPKgeQ6TJCZVQjwaOLaW8BfyWbPEa1SaiTH1VfSENd85NDxHt1plA71LKRvX4BDaAKFlTgLeALtliDUqPrSV6SQCBlypgFlbmIIrCDcAl6nPAawmYhlLKFuB6IrkXAadUNj6TXlhDcCNEB/Jn4FcE0f4UWEl0NyWNvZxGTs89z6ZnatIIrCdqcCtRJmcCPwCeSN3N1Iu6T4VaFhm9n+riypouBnepLsk9p6p35fzwvDSX5eVQvaDOzjnqzTl+1KC53+XzLINHd65O6lD1DnWbepPBhQ3q2jQyW+2oDkkAtdt5udpb7W+Q/OFGA7ol1zxu1tc8zNHqXercfDfQIOZm9fR815Cpt5PnVqsr1F51wI9QnzU63xZ1o/rdPPmt6enV6sXqHPVqdXOCe1rtrg5W7zNI+m712Ir+cer4POiqfHeJSVe1Raemwnm7xD3mD1E/Z3wIjcsTdlZnqO8bFeNB9c30zgVG2euYa69QJ+9G90lG+99bfdIoo5PU4w362xHePxl1slMab6tV72KUxDvzlAMT8G0ZohXq39VX1bNzzxij9K1Qb9lhdGe931B/kR6/zCwY9YvuytCsMlj+gbr5SemhqkyuzE8xau4MP865JvWNuj0b1YuqDkgvH2GkURfakly01Cg7Cw0+qyXxkjojq9Lw+vT2AUY+DlF/otYq1Ixc35re2V7R8aTRg2KUv7+ou3x/14PsUBn3NG51S0XpG0Z9PcOPKWSS0SKNUo9Rv2Mmt/G5WpPF6pHGra7Jv410OVsdaz217AbkAPX3ubkm240belCuudT4Rp5p/DyC2lf9mfq1iq5eFe8/lu+K0YrVp0uret4nAkwlB6vzjI/1PxrlrTp/oNHbzTJI92T1qAT+BfW49MhMg6JUp7ehY5a6Tl2jjmVvitF9fxo5Yq8CaAfAkzLMnySt6uz/1k6bPx59CpCNxGfoSKA30IPoH7cQXdArwCOllFX/i53P5P9a/gNkKpsCMFRuFAAAAABJRU5ErkJggg=="
-        label = "MoJ Compliant"
-
-        if repository is None:
-            color = STATUS_COLORS["unknown"]
-            message = "UNKNOWN"
-        else:
-            color = STATUS_COLORS.get(repository.compliance_status)
-            message = repository.compliance_status.capitalize()
-
-        shields_url = f"https://img.shields.io/badge/{quote(label)}-{quote(message)}-{color}?style=for-the-badge&labelColor=231f20&logo=data:image/png;base64,{quote(logo)}"
-        shields_response = requests.get(shields_url, stream=True)
-
-        return shields_response.content
-
     def get_repository_complaince_badge_shield_url_by_name(
         self, repository_name: str
     ) -> str:
         repository = self.get_repository_by_name(repository_name)
-        STATUS_COLORS = {
-            "pass": "005ea5",  # MoJ blue
-            "fail": "cc0000",  # Red
-            "unknown": "808080",  # Grey
-        }
-
         logo = "iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAABmJLR0QA/wD/AP+gvaeTAAAHJElEQVRYhe2YeYyW1RWHnzuMCzCIglBQlhSV2gICKlHiUhVBEAsxGqmVxCUUIV1i61YxadEoal1SWttUaKJNWrQUsRRc6tLGNlCXWGyoUkCJ4uCCSCOiwlTm6R/nfPjyMeDY8lfjSSZz3/fee87vnnPu75z3g8/kM2mfqMPVH6mf35t6G/ZgcJ/836Gdug4FjgO67UFn70+FDmjcw9xZaiegWX29lLLmE3QV4Glg8x7WbFfHlFIebS/ANj2oDgX+CXwA9AMubmPNvuqX1SnqKGAT0BFoVE9UL1RH7nSCUjYAL6rntBdg2Q3AgcAo4HDgXeBAoC+wrZQyWS3AWcDSUsomtSswEtgXaAGWlVI2q32BI0spj9XpPww4EVic88vaC7iq5Hz1BvVf6v3qe+rb6ji1p3pWrmtQG9VD1Jn5br+Knmm70T9MfUh9JaPQZu7uLsR9gEsJb3QF9gOagO7AuUTom1LpCcAkoCcwQj0VmJregzaipA4GphNe7w/MBearB7QLYCmlGdiWSm4CfplTHwBDgPHAFmB+Ah8N9AE6EGkxHLhaHU2kRhXc+cByYCqROs05NQq4oR7Lnm5xE9AL+GYC2gZ0Jmjk8VLKO+pE4HvAyYRnOwOH5N7NhMd/WKf3beApYBWwAdgHuCLn+tatbRtgJv1awhtd838LEeq30/A7wN+AwcBt+bwpD9AdOAkYVkpZXtVdSnlc7QI8BlwOXFmZ3oXkdxfidwmPrQXeA+4GuuT08QSdALxC3OYNhBe/TtzON4EziZBXD36o+q082BxgQuqvyYL6wtBY2TyEyJ2DgAXAzcC1+Xxw3RlGqiuJ6vE6QS9VGZ/7H02DDwAvELTyMDAxbfQBvggMAAYR9LR9J2cluH7AmnzuBowFFhLJ/wi7yiJgGXBLPq8A7idy9kPgvAQPcC9wERHSVcDtCfYj4E7gr8BRqWMjcXmeB+4tpbyG2kG9Sl2tPqF2Uick8B+7szyfvDhR3Z7vvq/2yqpynnqNeoY6v7LvevUU9QN1fZ3OTeppWZmeyzRoVu+rhbaHOledmoQ7LRd3SzBVeUo9Wf1DPs9X90/jX8m/e9Rn1Mnqi7nuXXW5+rK6oU7n64mjszovxyvVh9WeDcTVnl5KmQNcCMwvpbQA1xE8VZXhwDXAz4FWIkfnAlcBAwl6+SjD2wTcmPtagZnAEuA3dTp7qyNKKe8DW9UeBCeuBsbsWKVOUPvn+MRKCLeq16lXqLPVFvXb6r25dlaGdUx6cITaJ8fnpo5WI4Wuzcjcqn5Y8eI/1F+n3XvUA1N3v4ZamIEtpZRX1Y6Z/DUK2g84GrgHuDqTehpBCYend94jbnJ34DDgNGArQT9bict3Y3p1ZCnlSoLQb0sbgwjCXpY2blc7llLW1UAMI3o5CD4bmuOlwHaC6xakgZ4Z+ibgSxnOgcAI4uavI27jEII7909dL5VSrimlPKgeQ6TJCZVQjwaOLaW8BfyWbPEa1SaiTH1VfSENd85NDxHt1plA71LKRvX4BDaAKFlTgLeALtliDUqPrSV6SQCBlypgFlbmIIrCDcAl6nPAawmYhlLKFuB6IrkXAadUNj6TXlhDcCNEB/Jn4FcE0f4UWEl0NyWNvZxGTs89z6ZnatIIrCdqcCtRJmcCPwCeSN3N1Iu6T4VaFhm9n+riypouBnepLsk9p6p35fzwvDSX5eVQvaDOzjnqzTl+1KC53+XzLINHd65O6lD1DnWbepPBhQ3q2jQyW+2oDkkAtdt5udpb7W+Q/OFGA7ol1zxu1tc8zNHqXercfDfQIOZm9fR815Cpt5PnVqsr1F51wI9QnzU63xZ1o/rdPPmt6enV6sXqHPVqdXOCe1rtrg5W7zNI+m712Ir+cer4POiqfHeJSVe1Raemwnm7xD3mD1E/Z3wIjcsTdlZnqO8bFeNB9c30zgVG2euYa69QJ+9G90lG+99bfdIoo5PU4w362xHePxl1slMab6tV72KUxDvzlAMT8G0ZohXq39VX1bNzzxij9K1Qb9lhdGe931B/kR6/zCwY9YvuytCsMlj+gbr5SemhqkyuzE8xau4MP865JvWNuj0b1YuqDkgvH2GkURfakly01Cg7Cw0+qyXxkjojq9Lw+vT2AUY+DlF/otYq1Ixc35re2V7R8aTRg2KUv7+ou3x/14PsUBn3NG51S0XpG0Z9PcOPKWSS0SKNUo9Rv2Mmt/G5WpPF6pHGra7Jv410OVsdaz217AbkAPX3ubkm240belCuudT4Rp5p/DyC2lf9mfq1iq5eFe8/lu+K0YrVp0uret4nAkwlB6vzjI/1PxrlrTp/oNHbzTJI92T1qAT+BfW49MhMg6JUp7ehY5a6Tl2jjmVvitF9fxo5Yq8CaAfAkzLMnySt6uz/1k6bPx59CpCNxGfoSKA30IPoH7cQXdArwCOllFX/i53P5P9a/gNkKpsCMFRuFAAAAABJRU5ErkJggg=="
         label = "MoJ Compliant"
 
-        if repository is None:
-            color = STATUS_COLORS["unknown"]
-            message = "UNKNOWN"
-        else:
-            color = STATUS_COLORS.get(repository.compliance_status)
+        if repository and repository.compliance_status == "pass":
+            color = "005ea5"  # MoJ blue
             message = repository.compliance_status.capitalize()
+        elif repository and repository.compliance_status == "fail":
+            color = "cc0000"  # Red
+            message = repository.compliance_status.capitalize()
+        else:
+            color = "808080"  # Grey
+            message = "Not Found"
 
         return f"https://img.shields.io/badge/{quote(label)}-{quote(message)}-{color}?style=for-the-badge&labelColor=231f20&logo=data:image/png;base64,{quote(logo)}"
 

--- a/app/shared/config/routes_config.py
+++ b/app/shared/config/routes_config.py
@@ -1,10 +1,13 @@
 from flask import Flask
 
-from app.shared.routes.main import main
-from app.shared.routes.auth import auth_route
-from app.shared.routes.robots import robot_route
-from app.projects.repository_standards.routes.main import repository_standards_main
 from app.projects.repository_standards.routes.api import repository_standards_api
+from app.projects.repository_standards.routes.deprecated import (
+    repository_standards_deprecated,
+)
+from app.projects.repository_standards.routes.main import repository_standards_main
+from app.shared.routes.auth import auth_route
+from app.shared.routes.main import main
+from app.shared.routes.robots import robot_route
 
 
 def configure_routes(app: Flask) -> None:
@@ -18,3 +21,4 @@ def configure_routes(app: Flask) -> None:
     app.register_blueprint(
         repository_standards_api, url_prefix="/repository-standards/api"
     )
+    app.register_blueprint(repository_standards_deprecated, url_prefix="/")


### PR DESCRIPTION
## 👀 Purpose

- In relation to #27 
- To add legacy endpoints of the old repository reports, to ensure this service is backwards compatible to minimise impact on existing users

## ♻️ What's changed

- Added several legacy endpoints so that this app can continue to support older links to the badge

## 📝 Notes

- I have verified that these endpoints are still in use by active repositories - some being displayed broken due to the link being incorrect. For this, I have updated the message on that endpoint to provide guidance on where to go to fix it.