### PR TITLE
✨ Add Groups For Minor and Patch Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     commit-message:
       prefix: ":dependabot: github-actions"
       include: "scope"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
@@ -16,6 +21,11 @@ updates:
     commit-message:
       prefix: ":dependabot: devcontainers"
       include: "scope"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -23,3 +33,8 @@ updates:
     commit-message:
       prefix: ":dependabot: pip"
       include: "scope"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## 👀 Purpose

- To minimise noise of updates by grouping minor and patch updates

## ♻️ What's changed

- Added groups for minor and patch updates across all ecosystems for dependabot