### PR TITLE
🔥 Remove Canary Configuration

### DIFF
--- a/helm/github-community/templates/ingress-legacy.yaml
+++ b/helm/github-community/templates/ingress-legacy.yaml
@@ -12,8 +12,6 @@ metadata:
     cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"
     allow-duplicate-host: "true"
     allowed-duplicate-ns: "operations-engineering-reports-prod,github-community-prod"
-    nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "100"
 spec:
   ingressClassName: "default"
   tls:


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://mojdt.slack.com/archives/C57UPMZLY/p1742810087686529
- To stop Ingress traffic defaulting to this applicaiton

## ♻️ What's changed

- Removed Canary Ingress Annotations

## 📝 Notes

- Currently, the application is being used by several domains under `*.live.cloud-platform.service.justice.gov.uk` - we believe this may be due to the canary annotations, and the cluster defaulting to this ingress when the other's can't resolve