### PR TITLE
🔥 Remove Link to Legacy Report

### DIFF
--- a/app/templates/projects/repository_standards/pages/repository.html
+++ b/app/templates/projects/repository_standards/pages/repository.html
@@ -38,8 +38,6 @@
       <dt class="govuk-summary-list__key">References</dt>
       <dd class="govuk-summary-list__value">
         <a href="https://github.com/ministryofjustice/{{ repository.name }}" rel="noreferrer noopener" target="_blank" class="govuk-link">View Repository on GitHub</a>
-        <br />
-        <a href="https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/{{ repository.name }}" rel="noreferrer noopener" target="_blank" class="govuk-link">View Legacy Compliance Report</a>
       </dd>
     </div>
   </section>


### PR DESCRIPTION
## 👀 Purpose

- Remove redundant link to legacy report

## ♻️ What's changed

- Removed old link to legacy report