### PR TITLE
🔧 Fix `docker compose` Not Working By Defining `nonroot` Permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ ENV APP_DIRECTORY="/app" \
   PYTHONDONTWRITEBYTECODE="1" \
   PYTHONUNBUFFERED="1"
 
+# Set options for safe shell execution
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 
+# Setup the application directory
 RUN <<EOF
 groupadd \
   --gid ${CONTAINER_GID} \
@@ -31,13 +33,18 @@ useradd \
 install --directory --owner "${CONTAINER_USER}" --group "${CONTAINER_GROUP}" --mode 0755 "${APP_DIRECTORY}"
 EOF
 
+# Migrate files to the application directory
 WORKDIR ${APP_DIRECTORY}
-
 COPY Pipfile Pipfile
 COPY Pipfile.lock Pipfile.lock
 COPY app app
 COPY migrations migrations
 
+# Ensure nonroot user and group can read and write to the application directory
+RUN chown -R "${CONTAINER_USER}:${CONTAINER_GROUP}" "${APP_DIRECTORY}" \
+  && chmod -R u+rwX,g+rX,o+rX "${APP_DIRECTORY}"
+
+# Install pipenv and dependencies
 RUN <<EOF
 python3 -m pip install --no-cache-dir pipenv
 pipenv install --system --deploy --ignore-pipfile
@@ -45,6 +52,7 @@ EOF
 
 EXPOSE 4567
 
+# Switch to nonroot user
 USER ${CONTAINER_UID}
 
 ENTRYPOINT ["gunicorn", "--bind=0.0.0.0:4567", "app.run:app()"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,10 @@ EOF
 
 # Migrate files to the application directory
 WORKDIR ${APP_DIRECTORY}
-COPY Pipfile Pipfile
-COPY Pipfile.lock Pipfile.lock
-COPY app app
-COPY migrations migrations
-
-# Ensure nonroot user and group can read and write to the application directory
-RUN chown -R "${CONTAINER_USER}:${CONTAINER_GROUP}" "${APP_DIRECTORY}" \
-  && chmod -R u+rwX,g+rX,o+rX "${APP_DIRECTORY}"
+COPY --chown=${CONTAINER_UID}:${CONTAINER_GID} Pipfile Pipfile
+COPY --chown=${CONTAINER_UID}:${CONTAINER_GID} Pipfile.lock Pipfile.lock
+COPY --chown=${CONTAINER_UID}:${CONTAINER_GID} app app
+COPY --chown=${CONTAINER_UID}:${CONTAINER_GID} migrations migrations
 
 # Install pipenv and dependencies
 RUN <<EOF


### PR DESCRIPTION
## 👀 Purpose

- To ensure consistency in the Docker Build
- To fix the following error when running `docker compose` locally (due to permission errors for the `nonroot` user being used by the container):
```sh
ModuleNotFoundError: No module named 'app.projects.repository_standards.repositories.owner_repository'
```


## ♻️ What's changed

- Added the `--chown` flag to the `COPY` steps - which defines permissions for the `nonroot` user and groups to be able to read, write and execute the copied files