### PR TITLE
Add `technology-services` GitHub Team to repo standards

### DIFF
--- a/app/projects/repository_standards/config/owners_config.py
+++ b/app/projects/repository_standards/config/owners_config.py
@@ -48,6 +48,11 @@ owners_config = [
     ),
     Owner(
         name="Technology Services",
-        teams=["nvvs-devops-admins", "moj-official-techops", "cloud-ops-alz-admins"],
+        teams=[
+            "nvvs-devops-admins",
+            "moj-official-techops",
+            "cloud-ops-alz-admins",
+            "technology-services"
+        ],
     ),
 ]


### PR DESCRIPTION
Adds the `technology-services` GitHub Team to repo standards under the Technology Services owners.

https://github.com/orgs/ministryofjustice/teams/technology-services/members