### PR TITLE
🔧 Fix Technology Services Mapping by Using Team Name Instead of Slug

### DIFF
--- a/app/projects/repository_standards/config/owners_config.py
+++ b/app/projects/repository_standards/config/owners_config.py
@@ -52,7 +52,7 @@ owners_config = [
             "nvvs-devops-admins",
             "moj-official-techops",
             "cloud-ops-alz-admins",
-            "technology-services"
+            "Technology Services",
         ],
     ),
 ]


### PR DESCRIPTION
## 👀 Purpose

- Fixes #105 
- Forgot that we use the actual team name when comparing instead of the slug 🙈 So the last run didn't assign the repositories to Technology Services, this PR should fix that 🔧 

## ♻️ What's changed

- Update the config from `technology-services` to `Technology Services`