### PR TITLE
🙅 Don't let Dependabot deploy to Development

### DIFF
--- a/.github/workflows/cicd-deploy-to-development.yml
+++ b/.github/workflows/cicd-deploy-to-development.yml
@@ -68,6 +68,7 @@ jobs:
           tags: ${{ steps.ecr_login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
 
   deploy-to-development:
+    if: github.actor != 'dependabot[bot]'
     needs: [build-push-image]
     name: Deploy to Development
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed Changes

- Dependabot doesn't have permission to retrieve GitHub repository secrets so cannot assume the AWS OIDC role to deploy to development 
  - See https://github.com/ministryofjustice/github-community/actions/runs/17157561046/job/48678185554?pr=114 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>