### PR TITLE
🛡️ Enable Cloud Platform's ModSecurity WAF

### DIFF
--- a/.github/workflows/cicd-deploy-to-development.yml
+++ b/.github/workflows/cicd-deploy-to-development.yml
@@ -12,6 +12,9 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: development
+
 env:
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
   KUBE_NAMESPACE: ${{ secrets.DEV_KUBE_NAMESPACE }}

--- a/.github/workflows/cicd-deploy-to-production.yml
+++ b/.github/workflows/cicd-deploy-to-production.yml
@@ -9,6 +9,9 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: production
+
 env:
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
   KUBE_NAMESPACE: ${{ secrets.PROD_KUBE_NAMESPACE }}

--- a/helm/github-community/templates/ingress.yaml
+++ b/helm/github-community/templates/ingress.yaml
@@ -10,8 +10,12 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ $fullName }}-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team={{ .Values.app.ingress.modsec.githubTeam }}"
 spec:
-  ingressClassName: "default"
+  ingressClassName: "{{ .Values.app.ingress.modsec.ingressName }}"
   tls:
     - hosts:
       {{- range .Values.app.ingress.hosts }}

--- a/helm/github-community/values-dev.yaml
+++ b/helm/github-community/values-dev.yaml
@@ -2,6 +2,9 @@ app:
   ingress:
     hosts:
       - "github-community-dev.cloud-platform.service.justice.gov.uk"
+    modsec:
+      githubTeam: "github-community"
+      ingressName: "modsec-non-prod"
 
   deployment:
     replicaCount: 1

--- a/helm/github-community/values-prod.yaml
+++ b/helm/github-community/values-prod.yaml
@@ -5,6 +5,9 @@ app:
       - "github-community.service.justice.gov.uk"
       - "operations-engineering-reports.cloud-platform.service.justice.gov.uk"
       - "operations-engineering-reports-prod.cloud-platform.service.justice.gov.uk"
+    modsec:
+      githubTeam: "github-community"
+      ingressName: "modsec"
 
   deployment:
     replicaCount: 1


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/github-community/issues/87

## Proposed Changes

- Enables ModSecurity as per https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#quick-start
- Bonus: Adds [concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) to deployment workflows

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>