### PR TITLE
🙅 Don't let Dependabot deploy to Development (part 2)

### DIFF
--- a/.github/workflows/cicd-deploy-to-development.yml
+++ b/.github/workflows/cicd-deploy-to-development.yml
@@ -40,6 +40,7 @@ env:
 
 jobs:
   build-push-image:
+    if: github.actor != 'dependabot[bot]'
     name: Build and Push Image
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Proposed Changes

- Adds skip for image building (should've done that in https://github.com/ministryofjustice/github-community/pull/119)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>