### PR TITLE
🚏 Preserve Original Path For Post-Login Redirect

### DIFF
--- a/app/shared/middleware/auth.py
+++ b/app/shared/middleware/auth.py
@@ -4,6 +4,7 @@ from functools import wraps
 from flask import (
     redirect,
     session,
+    request,
 )
 
 from app.shared.config.app_config import app_config
@@ -15,6 +16,7 @@ def requires_auth(function_f):
     @wraps(function_f)
     def decorated(*args, **kwargs):
         if app_config.auth_enabled and "user" not in session:
+            session["post_auth_redirect_path"] = request.full_path
             return redirect("/auth/login")
         return function_f(*args, **kwargs)
 

--- a/app/shared/middleware/auth.py
+++ b/app/shared/middleware/auth.py
@@ -6,7 +6,7 @@ from flask import (
     session,
     request,
 )
-
+from time import time
 from app.shared.config.app_config import app_config
 
 logger = logging.getLogger(__name__)
@@ -15,7 +15,10 @@ logger = logging.getLogger(__name__)
 def requires_auth(function_f):
     @wraps(function_f)
     def decorated(*args, **kwargs):
-        if app_config.auth_enabled and "user" not in session:
+        if app_config.auth_enabled and (
+            "user" not in session or session["user"].get("expires_at", 0) < time()
+        ):
+            session.pop("user")
             session["post_auth_redirect_path"] = request.full_path
             return redirect("/auth/login")
         return function_f(*args, **kwargs)

--- a/app/shared/routes/auth.py
+++ b/app/shared/routes/auth.py
@@ -33,4 +33,7 @@ def logout():
 @auth_route.route("/callback", methods=["GET", "POST"])
 def callback():
     session["user"] = auth0_service.get_access_token()
+    path = session.pop("post_auth_redirect_path", None)
+    if path:
+        return redirect(path)
     return redirect("/")

--- a/app/shared/services/auth0_service.py
+++ b/app/shared/services/auth0_service.py
@@ -41,4 +41,4 @@ class Auth0_Service:
             },
             quote_via=quote_plus,
         )
-        return redirect(f"https://${self.domain}/v2/logout?${query_parameters}")
+        return redirect(f"https://{self.domain}/v2/logout?{query_parameters}")


### PR DESCRIPTION
## 👀 Purpose

- Fixes #150 

## ♻️ What's changed

- 💾 Added logic to store the initial path of the request before authentication, then updated the callback to route the user to their original destination
- 🦺 Added some logic to check the user session tokens' expiry and revoke the session after it expires
- Fixed the `/logout` endpoint (you might be able to tell I'd been writing javascript when I originally wrote that function 🤭) 

## 📝 Notes

- Tested in this in the dev environment and it all looks good! https://github-community-dev.cloud-platform.service.justice.gov.uk/repository-standards/unowned-repositories - you can now also hit https://github-community-dev.cloud-platform.service.justice.gov.uk/auth/logout to clear your session 🧪