### PR TITLE
🐛 Fix Auth Bug by Providing Default Value When Removing User Session

### DIFF
--- a/app/shared/middleware/auth.py
+++ b/app/shared/middleware/auth.py
@@ -18,7 +18,7 @@ def requires_auth(function_f):
         if app_config.auth_enabled and (
             "user" not in session or session["user"].get("expires_at", 0) < time()
         ):
-            session.pop("user")
+            session.pop("user", None)
             session["post_auth_redirect_path"] = request.full_path
             return redirect("/auth/login")
         return function_f(*args, **kwargs)


### PR DESCRIPTION
## 👀 Purpose

- In relation to [KeyError Issue In Sentry](https://ministryofjustice.sentry.io/issues/6864618111/?query=is%3Aunresolved%20issue.category%3A%5Berror%2Coutage%5D&referrer=issue-stream)

## ♻️ What's changed

- Added a default value when popping the user key in the session dictionary, to prevetn KeyError when "user" does not exist

## 📝 Notes

- This bug was introduced as part of #150