### PR TITLE
💅 Add Style Parameter to Badge API

### DIFF
--- a/app/projects/repository_standards/routes/api.py
+++ b/app/projects/repository_standards/routes/api.py
@@ -1,19 +1,26 @@
-import logging
-from urllib.parse import quote
+import requests
+from flask import Blueprint, Response, request
+
 from app.projects.repository_standards.services.repository_compliance_service import (
     get_repository_compliance_service,
 )
-import requests
-from flask import Blueprint, Response
 
 repository_standards_api = Blueprint("repository_standards_api", __name__)
 
 
 @repository_standards_api.route("/<repository_name>/badge", methods=["GET"])
 def get_repository_badge(repository_name: str):
+    default_badge_style = "for-the-badge"
+    valid_badge_styles = ["for-the-badge", "flat"]
+    style_parameter = request.args.get("style", default_badge_style, type=str)
+    style = (
+        style_parameter
+        if style_parameter in valid_badge_styles
+        else default_badge_style
+    )
     repository_compliance_service = get_repository_compliance_service()
     shields_url = repository_compliance_service.get_repository_complaince_badge_shield_url_by_name(
-        repository_name
+        repository_name, style
     )
     shields_response = requests.get(shields_url, stream=True)
     return Response(

--- a/app/projects/repository_standards/services/repository_compliance_service.py
+++ b/app/projects/repository_standards/services/repository_compliance_service.py
@@ -108,7 +108,7 @@ class RepositoryComplianceService:
         return repository_compliance_report
 
     def get_repository_complaince_badge_shield_url_by_name(
-        self, repository_name: str
+        self, repository_name: str, style: str = "for-the-badge"
     ) -> str:
         repository = self.get_repository_by_name(repository_name)
         logo = "iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEULDAwaGxsbGxsbHBwpKioqKioqKys5OTk5OjpISEhISUlJSUlXWFhYWFhYWVlmZ2dnZ2dnaGh1dnZ2dnZ2d3eEhYWFhYWFhoaUlJSUlZWVlZWjo6OjpKSkpKSys7Ozs7PBwsLCwsLDw8PR0dHR0tLS0tLg4ODh4eHw8PD////0W6DbAAACOElEQVQYGdXB4XYbJxAG0A8pi6YYuqPMdlgiLETWK+D9X7Cpj6PjpO2J/+Ze/KaOFh8j1eJDfDL4iOPaLH7NiqyqQvgFK0zz8+RCAODwv47MgBRg4gAYh39z+If3Ro1P1jJ5A5Az+Nmn4AwgLNvzbSv3QskArkbCj0zgwBNMdtWtNWQWxpS3dl/xE82XnYG6pZK5yd4NPt/a6JXwQLAwpeZrNeBS9t56ah7gKNso4Qhr8MrfdwepeW0BVNcYgvdZgDmke8+Ua8Gb5Cu4llztE2fSmJxNLlH05FOUXDzeTFhh4ku7VQ5x8fQnLJ6ClD7U4WImPAjDtvv4OrHzvLgzK7v1cq9juCMpHripbWMbPX8+XXPiSOK4nNIYoxcnjDfaV7uPfl/62J7nWf44k7Ct6lwbo2juweDVqnYdbQJiTrprCtHNjjM5QFqPPm54ZRKkjTp7eJl5Cecnf37y56xneL1+rQy1eMW3KKOPsbJ6f02UtGlSJubRK+dUVrwhuDF0fHGBXdI5Srkkr+yWEbkxToTvtO8xNeeE/e7nL7roykJh7lzKTnigez9M22hbnJVilnQtgVZdCfN0qBMeaG9AKNcqs5bMkywiM7sDsAAZ77ShHjg4TEUNO9GjygGASfAveG/ZEgCaZ7nQRDL75Gd3BHkqJ7znLqpx3/NLlyl4yKnlOZdvtgvhPTfyKlteVBKckYlUpbTntcR9wg+WKP4AwMbtL5K6Eb4h1nzGfzPrlpzetoAPOOA39TfuoTeEaSFm3gAAAABJRU5ErkJggg=="
@@ -132,7 +132,7 @@ class RepositoryComplianceService:
         color = config["color"]
         message = config["message"]
 
-        return f"https://img.shields.io/badge/{quote(label)}-{quote(message)}-{color}?style=for-the-badge&labelColor=0b0c0c&logo=data:image/png;base64,{logo}"
+        return f"https://img.shields.io/badge/{quote(label)}-{quote(message)}-{color}?style={style}&labelColor=0b0c0c&logo=data:image/png;base64,{logo}"
 
 
 def get_repository_compliance_service() -> RepositoryComplianceService:


### PR DESCRIPTION
## 👀 Purpose

- To support different style badges to improve new endpoint adoption

## ♻️ What's changed

- Added a style parameter to the badge api to allow use of a flat badge

## 📝 Notes

- Some teams are currently using the flat style badge; offering this option will hopefully improve adoption of the new endpoint, so we can deprecate the old endpoints
- Example of what the badge looks like with a flat style
![badge](https://github.com/user-attachments/assets/9074d4cf-bc26-4bfe-8c20-daf8596afc85)
