### PR TITLE
⏰ Adjust Mapper Job Times

### DIFF
--- a/helm/github-community/templates/map-github-repositories-to-owners-job.yaml
+++ b/helm/github-community/templates/map-github-repositories-to-owners-job.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:
-  schedule: "0 12 * * *"
+  schedule: "{{ .Values.app.jobs.map_github_repositories_to_owners.schedule }}"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 3
   startingDeadlineSeconds: 300

--- a/helm/github-community/values-dev.yaml
+++ b/helm/github-community/values-dev.yaml
@@ -14,3 +14,7 @@ app:
       FLASK_DEBUG: true
       PHASE_BANNER_TEXT: "ALPHA"
       AUTH_ENABLED: false
+
+  jobs:
+    map_github_repositories_to_owners:
+      schedule: "0 3 * * *"

--- a/helm/github-community/values-prod.yaml
+++ b/helm/github-community/values-prod.yaml
@@ -17,3 +17,7 @@ app:
       FLASK_DEBUG: true
       PHASE_BANNER_TEXT: "ALPHA"
       AUTH_ENABLED: true
+
+  jobs:
+    map_github_repositories_to_owners:
+      schedule: "0 6,9,12,15,18 * * *"


### PR DESCRIPTION
## 👀 Purpose

- To ensure a fresh data set for production during the day when people are making changes to repository settings
- Minimise chances of hitting API rate limits by ensuring no cross over times (especially between dev and prod)

## ♻️ What's changed

- Production mapper job now runs at 6am,9am,12am,3pm and 6pm every day
- Dev mapper job now runs at 3am every day