### PR TITLE
🔧 Fix govukFooter Error in Template

### DIFF
--- a/app/templates/shared/components/base.html
+++ b/app/templates/shared/components/base.html
@@ -114,3 +114,6 @@
     </script>
 {% endblock bodyEnd %}
 
+{% block govukFooter %}
+  {{ govukFooter({}) }}
+{% endblock %}


### PR DESCRIPTION
## 👀 Purpose

- Fixes:
```sh
app-1       |   File "/app/.venv/lib/python3.13/site-packages/jinja2/environment.py", line 942, in handle_exception
app-1       |     raise rewrite_traceback_stack(source=source)
app-1       |   File "/app/app/templates/shared/pages/errors/500.html", line 1, in top-level template code
app-1       |     {% extends "shared/components/base.html" %}
app-1       |     ^^^^^^^^^^^^^^^^^^^^^^^^^
app-1       |   File "/app/app/templates/shared/components/base.html", line 14, in top-level template code
app-1       |     {% extends 'govuk_frontend_jinja/template.html' %}
app-1       |     ^^^^^^^^^^^^^^^^^^^^^^^^^
app-1       |   File "/app/.venv/lib/python3.13/site-packages/govuk_frontend_jinja/templates/template.html", line 95, in top-level template code
app-1       |     {% block footer %}
app-1       |   File "/app/.venv/lib/python3.13/site-packages/govuk_frontend_jinja/templates/template.html", line 96, in block 'footer'
app-1       |     {% call _govukTemplateFooter() %}
app-1       |     ^^^^^^^^^^^^^^^^^^^
app-1       |   File "/app/.venv/lib/python3.13/site-packages/jinja2/runtime.py", line 784, in _invoke
app-1       |     rv = self._func(*arguments)
app-1       |   File "/app/.venv/lib/python3.13/site-packages/govuk_frontend_jinja/templates/template.html", line 88, in template
app-1       |     {%- if caller() | trim | length > 0 %}
app-1       |     ^^^^^^^^^^^^^^^^^^^
app-1       |   File "/app/.venv/lib/python3.13/site-packages/jinja2/runtime.py", line 784, in _invoke
app-1       |     rv = self._func(*arguments)
app-1       |   File "/app/.venv/lib/python3.13/site-packages/govuk_frontend_jinja/templates/template.html", line 98, in template
app-1       |     {% block govukFooter %}
app-1       |     ^^^^^^^^^^^^^^^^^
app-1       |   File "/app/.venv/lib/python3.13/site-packages/govuk_frontend_jinja/templates/template.html", line 99, in block 'govukFooter'
app-1       |     {{ govukFooter() }}
app-1       |     ^^^^^^^^^^^^^^^
app-1       |   File "/app/.venv/lib/python3.13/site-packages/jinja2/runtime.py", line 784, in _invoke
app-1       |     rv = self._func(*arguments)
app-1       |   File "/app/.venv/lib/python3.13/site-packages/govuk_frontend_jinja/templates/components/footer/macro.html", line 5, in template
app-1       |     <div class="govuk-footer {%- if params.classes %} {{ params.classes }}{% endif %}"
app-1       |     ^^^^^^^^^^^^^^^^^^^^^^^^^
app-1       |   File "/app/.venv/lib/python3.13/site-packages/jinja2/environment.py", line 490, in getattr
app-1       |     return getattr(obj, attribute)
app-1       | jinja2.exceptions.UndefinedError: parameter 'params' was not provided
```

## ♻️ What's changed

- Calls the govukFooter manually, as the base template doesn't seem to call this macro with the params

## 📝 Notes

- Line that seems to be the issue in the package - https://github.com/LandRegistry/govuk-frontend-jinja/blob/66fe0f856dfe6dbaa1ebec43b838562def01186f/govuk_frontend_jinja/templates/template.html#L99