### PR TITLE
✨ Add Relationship Update on Team Creation & Edit

### DIFF
--- a/app/projects/repository_standards/repositories/asset_repository.py
+++ b/app/projects/repository_standards/repositories/asset_repository.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import datetime, timedelta
 from typing import List
@@ -15,6 +16,7 @@ from app.projects.repository_standards.repositories.owner_repository import (
 class RepositoryView:
     def __init__(
         self,
+        id: int,
         name: str,
         owner_names: List[str],
         admin_owner_names: List[str],
@@ -24,6 +26,7 @@ class RepositoryView:
         team_admin_owner_names: List[str],
         data: RepositoryInfo,
     ):
+        self.id = id
         self.name = name
         self.admin_owner_names = admin_owner_names
         self.owner_names = owner_names
@@ -43,6 +46,7 @@ class RepositoryView:
         ]
 
         return cls(
+            id=asset.id,
             name=asset.name,
             owner_names=[owner.name for owner in owners],
             admin_owner_names=[owner.name for owner in admin_owners],
@@ -119,6 +123,10 @@ class AssetRepository:
     def find_by_name(self, name: str) -> List[Asset]:
         assets = self.db_session.query(Asset).filter(Asset.name == name).all()
         return assets
+
+    def find_by_id(self, asset_id: int) -> Asset | None:
+        asset = self.db_session.query(Asset).filter(Asset.id == asset_id).first()
+        return asset
 
     def update_relationship_with_owner(
         self, asset: Asset, owner: OwnerView, relationship_type: str

--- a/app/projects/repository_standards/routes/main.py
+++ b/app/projects/repository_standards/routes/main.py
@@ -145,6 +145,7 @@ def teams_owner(owner_id: str):
 @requires_auth
 def edit_team(owner_id: str):
     owner_service = get_owner_service()
+    relationships_service = get_relationships_service()
 
     owner = owner_service.find_by_id(owner_id)
     if owner is None:
@@ -161,8 +162,12 @@ def edit_team(owner_id: str):
         ]
 
         if github_teams and form_team_name:
-            logger.info("hit")
-            owner_service.update_by_id(owner_id, form_team_name, github_teams)
+            updated_owner = owner_service.update_by_id(
+                owner_id, form_team_name, github_teams
+            )
+            if updated_owner is None:
+                raise ValueError("Failed to update owner")
+            relationships_service.update_relationship_for_owner(updated_owner)
 
         return redirect(
             url_for("repository_standards_main.teams_owner", owner_id=owner.id)

--- a/app/projects/repository_standards/routes/main.py
+++ b/app/projects/repository_standards/routes/main.py
@@ -5,6 +5,9 @@ from flask import Blueprint, redirect, render_template, request, url_for
 from app.projects.repository_standards.repositories.owner_repository import (
     get_owner_repository,
 )
+from app.projects.repository_standards.services.relationships_service import (
+    get_relationships_service,
+)
 from app.projects.repository_standards.services.repository_compliance_service import (
     get_repository_compliance_service,
 )
@@ -177,6 +180,7 @@ def edit_team(owner_id: str):
 @requires_auth
 def add_team():
     owner_service = get_owner_service()
+    relationships_service = get_relationships_service()
 
     team_name = None
     github_teams = None
@@ -197,6 +201,7 @@ def add_team():
             if team is None:
                 raise ValueError("Failed to add team")
 
+            relationships_service.update_relationship_for_owner(team)
             return redirect(
                 url_for("repository_standards_main.teams_owner", owner_id=team.id)
             )

--- a/app/projects/repository_standards/services/asset_service.py
+++ b/app/projects/repository_standards/services/asset_service.py
@@ -43,6 +43,9 @@ class AssetService:
             asset, owner, relationship_type
         )
 
+    def find_asset_by_id(self, asset_id: int) -> Asset | None:
+        return self.__asset_repository.find_by_id(asset_id)
+
     def update_asset_by_name(self, name: str, data: dict) -> Asset:
         return self.__asset_repository.update_by_name(name, data)
 

--- a/app/projects/repository_standards/services/relationships_service.py
+++ b/app/projects/repository_standards/services/relationships_service.py
@@ -8,23 +8,26 @@ from app.projects.repository_standards.services.asset_service import (
     AssetService,
     get_asset_service,
 )
-from app.projects.repository_standards.services.owner_service import (
-    OwnerService,
-    get_owner_service,
-)
 
 logger = logging.getLogger(__name__)
 
 
 class RelationshipsService:
-    def __init__(self, owner_service: OwnerService, asset_service: AssetService):
-        self.__owner_service = owner_service
+    def __init__(self, asset_service: AssetService):
         self.__asset_service = asset_service
 
     def __contains_one_or_more(
-        self, values: List[str], list_to_check: List[str]
+        self, values: List[str], lists_to_check: list[list[str]]
     ) -> bool:
-        return any(value in list_to_check for value in values)
+        found = False
+
+        for value in values:
+            for list_to_check in lists_to_check:
+                if value in list_to_check:
+                    found = True
+
+        return found
+
     def update_relationship_for_owner(self, owner: OwnerView) -> None:
         logger.info(f"Mapping Repositories for Owner [ {owner.name} ]")
 
@@ -45,7 +48,10 @@ class RelationshipsService:
 
             if self.__contains_one_or_more(
                 owner.config.teams,
-                repository.data.access.teams_with_admin,
+                [
+                    repository.data.access.teams_with_admin,
+                    repository.data.access.teams_with_admin_parents,
+                ],
             ):
                 self.__asset_service.update_relationships_with_owner(
                     asset, owner, "ADMIN_ACCESS"
@@ -53,7 +59,10 @@ class RelationshipsService:
             elif (
                 self.__contains_one_or_more(
                     owner.config.teams,
-                    repository.data.access.teams,
+                    [
+                        repository.data.access.teams,
+                        repository.data.access.teams_parents,
+                    ],
                 )
                 or repository_name_starts_with_prefix
             ):
@@ -64,7 +73,6 @@ class RelationshipsService:
 
 def get_relationships_service() -> RelationshipsService:
     if "relationships_service" not in g:
-        g.relationships_service = RelationshipsService(
-            get_owner_service(), get_asset_service()
-        )
+        g.relationships_service = RelationshipsService(get_asset_service())
     return g.relationships_service
+

--- a/app/projects/repository_standards/services/relationships_service.py
+++ b/app/projects/repository_standards/services/relationships_service.py
@@ -19,14 +19,12 @@ class RelationshipsService:
     def __contains_one_or_more(
         self, values: List[str], lists_to_check: list[list[str]]
     ) -> bool:
-        found = False
-
         for value in values:
             for list_to_check in lists_to_check:
                 if value in list_to_check:
-                    found = True
+                    return True
 
-        return found
+        return False
 
     def update_relationship_for_owner(self, owner: OwnerView) -> None:
         logger.info(f"Mapping Repositories for Owner [ {owner.name} ]")

--- a/app/projects/repository_standards/services/relationships_service.py
+++ b/app/projects/repository_standards/services/relationships_service.py
@@ -1,0 +1,77 @@
+import logging
+from typing import List
+
+from flask import g
+
+from app.projects.repository_standards.repositories.owner_repository import OwnerView
+from app.projects.repository_standards.services.asset_service import (
+    AssetService,
+    get_asset_service,
+)
+from app.projects.repository_standards.services.owner_service import (
+    OwnerService,
+    get_owner_service,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RelationshipsService:
+    def __init__(self, owner_service: OwnerService, asset_service: AssetService):
+        self.__owner_service = owner_service
+        self.__asset_service = asset_service
+
+    def __contains_one_or_more(
+        self, values: List[str], list_to_check: List[str]
+    ) -> bool:
+        found = False
+
+        for value in values:
+            if value in list_to_check:
+                found = True
+
+        return found
+
+    def update_relationship_for_owner(self, owner: OwnerView) -> None:
+        logger.info(f"Mapping Repositories for Owner [ {owner.name} ]")
+
+        repositories = self.__asset_service.get_all_repositories()
+        for repository in repositories:
+            logger.debug(f"Mapping Repository [ {repository.name} ]")
+
+            asset = self.__asset_service.find_asset_by_id(repository.id)
+            if asset is None:
+                logger.error(f"Missing Asset ID [ {repository.id} ]")
+                continue
+
+            repository_name_starts_with_prefix = (
+                repository.name.startswith(owner.config.prefix)
+                if owner.config.prefix
+                else False
+            )
+
+            if self.__contains_one_or_more(
+                owner.config.teams,
+                repository.data.access.teams_with_admin,
+            ):
+                self.__asset_service.update_relationships_with_owner(
+                    asset, owner, "ADMIN_ACCESS"
+                )
+            elif (
+                self.__contains_one_or_more(
+                    owner.config.teams,
+                    repository.data.access.teams,
+                )
+                or repository_name_starts_with_prefix
+            ):
+                self.__asset_service.update_relationships_with_owner(
+                    asset, owner, "OTHER"
+                )
+
+
+def get_relationships_service() -> RelationshipsService:
+    if "relationships_service" not in g:
+        g.relationships_service = RelationshipsService(
+            get_owner_service(), get_asset_service()
+        )
+    return g.relationships_service

--- a/app/projects/repository_standards/services/relationships_service.py
+++ b/app/projects/repository_standards/services/relationships_service.py
@@ -24,14 +24,7 @@ class RelationshipsService:
     def __contains_one_or_more(
         self, values: List[str], list_to_check: List[str]
     ) -> bool:
-        found = False
-
-        for value in values:
-            if value in list_to_check:
-                found = True
-
-        return found
-
+        return any(value in list_to_check for value in values)
     def update_relationship_for_owner(self, owner: OwnerView) -> None:
         logger.info(f"Mapping Repositories for Owner [ {owner.name} ]")
 

--- a/contrib/db-init/01-stub-repository-standards-data.sql
+++ b/contrib/db-init/01-stub-repository-standards-data.sql
@@ -1,35 +1,35 @@
 INSERT INTO public.assets (id, name, type, last_updated, data) VALUES
-(1, 'asset-alpha', 'REPOSITORY', NOW(), '{
+(101, 'asset-alpha', 'REPOSITORY', NOW(), '{
   "basic":{"name":"asset-alpha", "visibility":"public", "delete_branch_on_merge":null, "default_branch_name":"main", "description":"Sample repo alpha", "license":"mit"},
   "access":{"teams_with_admin":["team-alpha"], "teams_with_admin_parents":[], "teams":["team-alpha"], "teams_parents":[]},
   "security_and_analysis":{"secret_scanning_status":"enabled", "push_protection_status":"enabled", "non_provider_patterns":"enabled"},
   "default_branch_protection":{"allow_force_pushes":true, "enforce_admins":true, "require_code_owner_reviews":true, "dismiss_stale_reviews":true, "required_approving_review_count": 1, "required_signatures":true}
   }'),
-(2, 'asset-bravo', 'REPOSITORY', NOW(), '{
+(102, 'asset-bravo', 'REPOSITORY', NOW(), '{
   "basic":{"name":"asset-bravo", "visibility":"public", "delete_branch_on_merge":null, "default_branch_name":"main", "description":"Sample repo bravo", "license":"mit"},
   "access":{"teams_with_admin":["team-bravo"], "teams_with_admin_parents":[], "teams":["team-bravo"], "teams_parents":[]},
   "security_and_analysis":{"secret_scanning_status":"enabled", "push_protection_status":"enabled", "non_provider_patterns":"enabled"},
   "default_branch_protection":{"allow_force_pushes":true, "enforce_admins":true, "require_code_owner_reviews":true, "dismiss_stale_reviews":true, "required_approving_review_count": 1}
   }'),
-(3, 'asset-charlie', 'REPOSITORY', NOW(), '{
+(103, 'asset-charlie', 'REPOSITORY', NOW(), '{
   "basic":{"name":"asset-charlie", "visibility":"public", "delete_branch_on_merge":null, "default_branch_name":"main", "description":"Sample repo charlie", "license":"gpl-3.0"},
   "access":{"teams_with_admin":["team-charlie"], "teams_with_admin_parents":[], "teams":["team-charlie"], "teams_parents":[]},
   "security_and_analysis":{"secret_scanning_status":"enabled", "push_protection_status":"enabled", "non_provider_patterns":"enabled"},
   "default_branch_protection":{"allow_force_pushes":false, "enforce_admins":true, "require_code_owner_reviews":true}
   }'),
-(4, 'asset-delta', 'REPOSITORY', NOW(), '{
+(104, 'asset-delta', 'REPOSITORY', NOW(), '{
   "basic":{"name":"asset-delta", "visibility":"public", "delete_branch_on_merge":null, "default_branch_name":"main", "description":"Sample repo delta", "license":"apache-2.0"},
   "access":{"teams_with_admin":["team-delta"], "teams_with_admin_parents":[], "teams":["team-delta"], "teams_parents":[]},
   "security_and_analysis":{"secret_scanning_status":"enabled", "push_protection_status":"enabled", "non_provider_patterns":"enabled"},
   "default_branch_protection":{"allow_force_pushes":false, "enforce_admins":true, "require_code_owner_reviews":true}
   }'),
-(5, 'asset-echo', 'REPOSITORY', NOW(), '{
+(105, 'asset-echo', 'REPOSITORY', NOW(), '{
   "basic":{"name":"asset-echo", "visibility":"public", "delete_branch_on_merge":null, "default_branch_name":"main", "description":"Sample repo echo", "license":"mit"},
   "access":{"teams_with_admin":["team-echo"], "teams_with_admin_parents":[], "teams":["team-echo"], "teams_parents":[]},
   "security_and_analysis":{"secret_scanning_status":"enabled", "push_protection_status":"disabled", "non_provider_patterns":"enabled"},
   "default_branch_protection":{"allow_force_pushes":false, "enforce_admins":true, "require_code_owner_reviews":true}
   }'),
-(6, 'asset-foxtrot', 'REPOSITORY', NOW(), '{
+(106, 'asset-foxtrot', 'REPOSITORY', NOW(), '{
   "basic":{"name":"asset-foxtrot", "visibility":"public", "delete_branch_on_merge":null, "default_branch_name":"main", "description":"Sample repo foxtrot", "license":"mit"},
   "access":{"teams_with_admin":["team-foxtrot"], "teams_with_admin_parents":[], "teams":["team-foxtrot"], "teams_parents":[]},
   "security_and_analysis":{"secret_scanning_status":"enabled", "push_protection_status":"enabled", "non_provider_patterns":"enabled"},
@@ -39,14 +39,14 @@ INSERT INTO public.assets (id, name, type, last_updated, data) VALUES
 INSERT INTO public.relationships
 (id, type, assets_id, owners_id, last_updated)
 VALUES
-(1, 'ADMIN_ACCESS', 1, 6, NOW()),
-(2, 'ADMIN_ACCESS', 1, 8, NOW()),
-(3, 'ADMIN_ACCESS', 3, 3, NOW()),
-(4, 'ADMIN_ACCESS', 4, 4, NOW()),
-(5, 'ADMIN_ACCESS', 5, 5, NOW()),
-(6, 'OTHER', 1, 2, NOW()),
-(7, 'OTHER', 2, 3, NOW()),
-(8, 'OTHER', 3, 4, NOW()),
-(9, 'OTHER', 4, 5, NOW()),
-(10, 'OTHER', 5, 8, NOW()),
-(11, 'ADMIN_ACCESS', 3, 1, NOW());
+(101, 'ADMIN_ACCESS', 101, 6, NOW()),
+(102, 'ADMIN_ACCESS', 101, 8, NOW()),
+(103, 'ADMIN_ACCESS', 103, 3, NOW()),
+(104, 'ADMIN_ACCESS', 104, 4, NOW()),
+(105, 'ADMIN_ACCESS', 105, 5, NOW()),
+(106, 'OTHER', 101, 2, NOW()),
+(107, 'OTHER', 102, 3, NOW()),
+(108, 'OTHER', 103, 4, NOW()),
+(109, 'OTHER', 104, 5, NOW()),
+(110, 'OTHER', 105, 8, NOW()),
+(111, 'ADMIN_ACCESS', 103, 1, NOW());


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/github-community/issues/403
- To enable teams to get compliance insights as soon as they create/edit a team (instead of waiting for the job to run)

## ♻️ What's changed

- Added a new RelationshipsService, which is responsible for updating relationships between assets and owners
- Updated the /teams/add-team endpoint to update the relationships for the newly created team 
- Updated the /teams/<owner_id>/edit endpoint to update the relationships when a user edits a team

## 📝 Notes

- This new functionality does not yet work for Editing Teams - this will come in a separate PR