### PR TITLE
Refactor BU and Teams into tables

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,2 @@
+app/static/javascript/
+migrations/versions/

--- a/.codespellignore
+++ b/.codespellignore
@@ -1,2 +1,0 @@
-app/static/javascript/
-migrations/versions/

--- a/app/projects/repository_standards/config/repository_compliance_config.py
+++ b/app/projects/repository_standards/config/repository_compliance_config.py
@@ -24,7 +24,7 @@ def get_secret_scanning_enabled_check(
         else FAIL,
         required=required,
         maturity_level=BASELINE,
-        description="Imporves organisational security by scanning and reporting secrets.",
+        description="Improves organisational security by scanning and reporting secrets.",
         link_to_guidance="/repository-standards/guidance#secret-scanning-enabled",
     )
 
@@ -133,7 +133,7 @@ def get_default_branch_protection_requires_atleast_one_review_check(
     repository: RepositoryView, required: bool = False
 ) -> RepositoryComplianceCheck:
     return RepositoryComplianceCheck(
-        name="Default Branch Pull Request Requires Atleast One Review",
+        name="Default Branch Pull Request Requires At Least One Review",
         status=PASS
         if repository.data.default_branch_protection.required_approving_review_count
         or (
@@ -155,7 +155,7 @@ def get_has_authorative_owner_check(
     authorative_owner: Optional[List[str]], required: bool = False
 ) -> RepositoryComplianceCheck:
     return RepositoryComplianceCheck(
-        name="Has an Authorative Owner",
+        name="Has an Authoritative Owner",
         status=PASS if authorative_owner else FAIL,
         required=required,
         maturity_level=STANDARD,

--- a/app/projects/repository_standards/config/repository_compliance_config.py
+++ b/app/projects/repository_standards/config/repository_compliance_config.py
@@ -151,12 +151,12 @@ def get_default_branch_protection_requires_atleast_one_review_check(
     )
 
 
-def get_has_authorative_owner_check(
-    authorative_owner: Optional[List[str]], required: bool = False
+def get_has_authoritative_owner_check(
+    authoritative_owner: Optional[List[str]], required: bool = False
 ) -> RepositoryComplianceCheck:
     return RepositoryComplianceCheck(
         name="Has an Authoritative Owner",
-        status=PASS if authorative_owner else FAIL,
+        status=PASS if authoritative_owner else FAIL,
         required=required,
         maturity_level=STANDARD,
         description="Prevents orphaned repositories by having an easily identifiable owner.",
@@ -191,7 +191,7 @@ def get_default_branch_is_main_check(
 
 
 def get_all_compliance_checks(
-    repository: RepositoryView, authorative_owner: Optional[List[str]]
+    repository: RepositoryView, authoritative_owner: Optional[List[str]]
 ) -> List[RepositoryComplianceCheck]:
     return [
         get_secret_scanning_enabled_check(repository),
@@ -201,7 +201,7 @@ def get_all_compliance_checks(
         get_default_branch_protection_requires_code_owner_reviews_check(repository),
         get_default_branch_pull_requests_dismiss_stale_reviews_check(repository),
         get_default_branch_protection_requires_atleast_one_review_check(repository),
-        get_has_authorative_owner_check(authorative_owner),
+        get_has_authoritative_owner_check(authoritative_owner),
         get_licence_is_mit_check(repository),
         get_default_branch_is_main_check(repository),
     ]

--- a/app/projects/repository_standards/models/owner.py
+++ b/app/projects/repository_standards/models/owner.py
@@ -31,5 +31,5 @@ class OwnerConfig:
             or data.get("teams") is None
             or data.get("prefix") is None
         ):
-            raise ValueError("Owner conifig is missing attributes")
+            raise ValueError("Owner config is missing attributes")
         return cls(name=data["name"], teams=data["teams"], prefix=data["prefix"])

--- a/app/projects/repository_standards/models/repository_compliance.py
+++ b/app/projects/repository_standards/models/repository_compliance.py
@@ -18,6 +18,6 @@ class RepositoryComplianceReportView:
     compliance_status: str
     checks: List[RepositoryComplianceCheck]
     maturity_level: int = 0
-    authorative_business_unit_owners: List[str] = field(default_factory=lambda: [])
-    authorative_team_owners: List[str] = field(default_factory=lambda: [])
+    authoritative_business_unit_owners: List[str] = field(default_factory=lambda: [])
+    authoritative_team_owners: List[str] = field(default_factory=lambda: [])
     description: Optional[str] = None

--- a/app/projects/repository_standards/routes/main.py
+++ b/app/projects/repository_standards/routes/main.py
@@ -188,9 +188,17 @@ def teams_owner(owner_id: str):
     return render_template(
         "projects/repository_standards/pages/team.html",
         repositories=filtrated_repositories,
+        baseline_maturity_level_repositories=[
+            repo for repo in filtrated_repositories if repo.maturity_level >= 1
+        ],
+        standard_maturity_level_repositories=[
+            repo for repo in filtrated_repositories if repo.maturity_level >= 2
+        ],
+        exemplar_maturity_level_repositories=[
+            repo for repo in filtrated_repositories if repo.maturity_level >= 3
+        ],
         owner=owner,
     )
-
 
 @repository_standards_main.route("/teams/<owner_id>/edit", methods=["GET", "POST"])
 @requires_auth

--- a/app/projects/repository_standards/routes/main.py
+++ b/app/projects/repository_standards/routes/main.py
@@ -56,12 +56,50 @@ def repositories():
 @repository_standards_main.route("/business-units", methods=["GET"])
 @requires_auth
 def business_units():
+    repository_compliance_service = get_repository_compliance_service()
     owner_repository = get_owner_repository()
     business_units = owner_repository.find_all_business_units()
+    repositories = repository_compliance_service.get_all_repositories()
+
+    business_unit_name_to_id = {
+        business_unit.name: business_unit.id for business_unit in business_units
+    }
+
+    business_unit_counts = defaultdict(
+        lambda: {
+            "repo_count": 0,
+            "baseline_compliant_count": 0,
+            "standard_compliant_count": 0,
+            "exemplar_compliant_count": 0,
+        }
+    )
+
+    for repo in repositories:
+        maturity_level = repo.maturity_level
+        business_unit_ids_for_repository = {
+            business_unit_name_to_id[owner_name]
+            for owner_name in repo.authoritative_business_unit_owners
+            if owner_name in business_unit_name_to_id
+        }
+
+        for business_unit_id in business_unit_ids_for_repository:
+            business_unit_counts[business_unit_id]["repo_count"] += 1
+            if maturity_level >= 1:
+                business_unit_counts[business_unit_id]["baseline_compliant_count"] += 1
+            if maturity_level >= 2:
+                business_unit_counts[business_unit_id]["standard_compliant_count"] += 1
+            if maturity_level >= 3:
+                business_unit_counts[business_unit_id]["exemplar_compliant_count"] += 1
+
+    business_unit_counts = {
+        business_unit.id: business_unit_counts[business_unit.id]
+        for business_unit in business_units
+    }
 
     return render_template(
         "projects/repository_standards/pages/business_units.html",
         business_unit_names=business_units,
+        business_unit_counts=business_unit_counts,
     )
 
 
@@ -162,15 +200,6 @@ def teams_owner(owner_id: str):
     return render_template(
         "projects/repository_standards/pages/team.html",
         repositories=filtrated_repositories,
-        baseline_maturity_level_repositories=[
-            repo for repo in filtrated_repositories if repo.maturity_level >= 1
-        ],
-        standard_maturity_level_repositories=[
-            repo for repo in filtrated_repositories if repo.maturity_level >= 2
-        ],
-        exemplar_maturity_level_repositories=[
-            repo for repo in filtrated_repositories if repo.maturity_level >= 3
-        ],
         owner=owner,
     )
 

--- a/app/projects/repository_standards/routes/main.py
+++ b/app/projects/repository_standards/routes/main.py
@@ -100,12 +100,57 @@ def business_units_owner(owner_id: str):
 @repository_standards_main.route("/teams", methods=["GET"])
 @requires_auth
 def teams():
+    repository_compliance_service = get_repository_compliance_service()
     owner_repository = get_owner_repository()
     teams = owner_repository.find_all_teams()
+    repositories = repository_compliance_service.get_all_repositories()
+    team_repository_counts = {
+        team.id: len(
+            [repo for repo in repositories if team.name in repo.authorative_team_owners]
+        )
+        for team in teams
+    }
+    team_baseline_compliant_counts = {
+        team.id: len(
+            [
+                repo
+                for repo in repositories
+                if team.name in repo.authorative_team_owners
+                and repo.maturity_level >= 1
+            ]
+        )
+        for team in teams
+    }
+    team_standard_compliant_counts = {
+        team.id: len(
+            [
+                repo
+                for repo in repositories
+                if team.name in repo.authorative_team_owners
+                and repo.maturity_level >= 2
+            ]
+        )
+        for team in teams
+    }
+    team_exemplar_compliant_counts = {
+        team.id: len(
+            [
+                repo
+                for repo in repositories
+                if team.name in repo.authorative_team_owners
+                and repo.maturity_level >= 3
+            ]
+        )
+        for team in teams
+    }
 
     return render_template(
         "projects/repository_standards/pages/teams.html",
         teams=teams,
+        team_repository_counts=team_repository_counts,
+        team_baseline_compliant_counts=team_baseline_compliant_counts,
+        team_standard_compliant_counts=team_standard_compliant_counts,
+        team_exemplar_compliant_counts=team_exemplar_compliant_counts,
     )
 
 

--- a/app/projects/repository_standards/routes/main.py
+++ b/app/projects/repository_standards/routes/main.py
@@ -1,5 +1,4 @@
 import logging
-from collections import defaultdict
 
 from flask import Blueprint, redirect, render_template, request, url_for
 
@@ -21,50 +20,6 @@ from app.shared.middleware.auth import requires_auth
 logger = logging.getLogger(__name__)
 
 repository_standards_main = Blueprint("repository_standards_main", __name__)
-
-
-def aggregate_owner_counts(entities, repositories, owner_field_name):
-    """
-    Aggregates repository compliance counts by owner (team or business unit).
-
-    Args:
-        entities: List of team or business unit objects with .name and .id attributes
-        repositories: List of repository objects
-        owner_field_name: Repository field to check (e.g., "authoritative_team_owners")
-
-    Returns:
-        Dictionary mapping entity.id to count dict with repo_count, baseline/standard/exemplar_compliant_count
-    """
-    name_to_id = {entity.name: entity.id for entity in entities}
-
-    counts = defaultdict(
-        lambda: {
-            "repo_count": 0,
-            "baseline_compliant_count": 0,
-            "standard_compliant_count": 0,
-            "exemplar_compliant_count": 0,
-        }
-    )
-
-    for repo in repositories:
-        maturity_level = repo.maturity_level
-        owner_names = getattr(repo, owner_field_name, [])
-        entity_ids_for_repository = {
-            name_to_id[owner_name]
-            for owner_name in owner_names
-            if owner_name in name_to_id
-        }
-
-        for entity_id in entity_ids_for_repository:
-            counts[entity_id]["repo_count"] += 1
-            if maturity_level >= 1:
-                counts[entity_id]["baseline_compliant_count"] += 1
-            if maturity_level >= 2:
-                counts[entity_id]["standard_compliant_count"] += 1
-            if maturity_level >= 3:
-                counts[entity_id]["exemplar_compliant_count"] += 1
-
-    return {entity.id: counts[entity.id] for entity in entities}
 
 
 
@@ -104,10 +59,9 @@ def business_units():
     repository_compliance_service = get_repository_compliance_service()
     owner_repository = get_owner_repository()
     business_units = owner_repository.find_all_business_units()
-    repositories = repository_compliance_service.get_all_repositories()
 
-    business_unit_counts = aggregate_owner_counts(
-        business_units, repositories, "authoritative_business_unit_owners"
+    business_unit_counts = repository_compliance_service.aggregate_owner_counts(
+        business_units
     )
 
     return render_template(
@@ -156,10 +110,9 @@ def teams():
     repository_compliance_service = get_repository_compliance_service()
     owner_repository = get_owner_repository()
     teams = owner_repository.find_all_teams()
-    repositories = repository_compliance_service.get_all_repositories()
 
-    team_counts = aggregate_owner_counts(
-        teams, repositories, "authoritative_team_owners"
+    team_counts = repository_compliance_service.aggregate_owner_counts(
+        teams
     )
 
     return render_template(

--- a/app/projects/repository_standards/routes/main.py
+++ b/app/projects/repository_standards/routes/main.py
@@ -23,6 +23,51 @@ logger = logging.getLogger(__name__)
 repository_standards_main = Blueprint("repository_standards_main", __name__)
 
 
+def aggregate_owner_counts(entities, repositories, owner_field_name):
+    """
+    Aggregates repository compliance counts by owner (team or business unit).
+
+    Args:
+        entities: List of team or business unit objects with .name and .id attributes
+        repositories: List of repository objects
+        owner_field_name: Repository field to check (e.g., "authoritative_team_owners")
+
+    Returns:
+        Dictionary mapping entity.id to count dict with repo_count, baseline/standard/exemplar_compliant_count
+    """
+    name_to_id = {entity.name: entity.id for entity in entities}
+
+    counts = defaultdict(
+        lambda: {
+            "repo_count": 0,
+            "baseline_compliant_count": 0,
+            "standard_compliant_count": 0,
+            "exemplar_compliant_count": 0,
+        }
+    )
+
+    for repo in repositories:
+        maturity_level = repo.maturity_level
+        owner_names = getattr(repo, owner_field_name, [])
+        entity_ids_for_repository = {
+            name_to_id[owner_name]
+            for owner_name in owner_names
+            if owner_name in name_to_id
+        }
+
+        for entity_id in entity_ids_for_repository:
+            counts[entity_id]["repo_count"] += 1
+            if maturity_level >= 1:
+                counts[entity_id]["baseline_compliant_count"] += 1
+            if maturity_level >= 2:
+                counts[entity_id]["standard_compliant_count"] += 1
+            if maturity_level >= 3:
+                counts[entity_id]["exemplar_compliant_count"] += 1
+
+    return {entity.id: counts[entity.id] for entity in entities}
+
+
+
 @repository_standards_main.route("/", methods=["GET"])
 @requires_auth
 def index():
@@ -61,40 +106,9 @@ def business_units():
     business_units = owner_repository.find_all_business_units()
     repositories = repository_compliance_service.get_all_repositories()
 
-    business_unit_name_to_id = {
-        business_unit.name: business_unit.id for business_unit in business_units
-    }
-
-    business_unit_counts = defaultdict(
-        lambda: {
-            "repo_count": 0,
-            "baseline_compliant_count": 0,
-            "standard_compliant_count": 0,
-            "exemplar_compliant_count": 0,
-        }
+    business_unit_counts = aggregate_owner_counts(
+        business_units, repositories, "authoritative_business_unit_owners"
     )
-
-    for repo in repositories:
-        maturity_level = repo.maturity_level
-        business_unit_ids_for_repository = {
-            business_unit_name_to_id[owner_name]
-            for owner_name in repo.authoritative_business_unit_owners
-            if owner_name in business_unit_name_to_id
-        }
-
-        for business_unit_id in business_unit_ids_for_repository:
-            business_unit_counts[business_unit_id]["repo_count"] += 1
-            if maturity_level >= 1:
-                business_unit_counts[business_unit_id]["baseline_compliant_count"] += 1
-            if maturity_level >= 2:
-                business_unit_counts[business_unit_id]["standard_compliant_count"] += 1
-            if maturity_level >= 3:
-                business_unit_counts[business_unit_id]["exemplar_compliant_count"] += 1
-
-    business_unit_counts = {
-        business_unit.id: business_unit_counts[business_unit.id]
-        for business_unit in business_units
-    }
 
     return render_template(
         "projects/repository_standards/pages/business_units.html",
@@ -144,35 +158,9 @@ def teams():
     teams = owner_repository.find_all_teams()
     repositories = repository_compliance_service.get_all_repositories()
 
-    team_name_to_id = {team.name: team.id for team in teams}
-
-    team_counts = defaultdict(
-        lambda: {
-            "repo_count": 0,
-            "baseline_compliant_count": 0,
-            "standard_compliant_count": 0,
-            "exemplar_compliant_count": 0,
-        }
+    team_counts = aggregate_owner_counts(
+        teams, repositories, "authoritative_team_owners"
     )
-
-    for repo in repositories:
-        maturity_level = repo.maturity_level
-        team_ids_for_repository = {
-            team_name_to_id[owner_name]
-            for owner_name in repo.authoritative_team_owners
-            if owner_name in team_name_to_id
-        }
-
-        for team_id in team_ids_for_repository:
-            team_counts[team_id]["repo_count"] += 1
-            if maturity_level >= 1:
-                team_counts[team_id]["baseline_compliant_count"] += 1
-            if maturity_level >= 2:
-                team_counts[team_id]["standard_compliant_count"] += 1
-            if maturity_level >= 3:
-                team_counts[team_id]["exemplar_compliant_count"] += 1
-
-    team_counts = {team.id: team_counts[team.id] for team in teams}
 
     return render_template(
         "projects/repository_standards/pages/teams.html",

--- a/app/projects/repository_standards/routes/main.py
+++ b/app/projects/repository_standards/routes/main.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 
 from flask import Blueprint, redirect, render_template, request, url_for
 
@@ -104,53 +105,41 @@ def teams():
     owner_repository = get_owner_repository()
     teams = owner_repository.find_all_teams()
     repositories = repository_compliance_service.get_all_repositories()
-    team_repository_counts = {
-        team.id: len(
-            [repo for repo in repositories if team.name in repo.authorative_team_owners]
-        )
-        for team in teams
-    }
-    team_baseline_compliant_counts = {
-        team.id: len(
-            [
-                repo
-                for repo in repositories
-                if team.name in repo.authorative_team_owners
-                and repo.maturity_level >= 1
-            ]
-        )
-        for team in teams
-    }
-    team_standard_compliant_counts = {
-        team.id: len(
-            [
-                repo
-                for repo in repositories
-                if team.name in repo.authorative_team_owners
-                and repo.maturity_level >= 2
-            ]
-        )
-        for team in teams
-    }
-    team_exemplar_compliant_counts = {
-        team.id: len(
-            [
-                repo
-                for repo in repositories
-                if team.name in repo.authorative_team_owners
-                and repo.maturity_level >= 3
-            ]
-        )
-        for team in teams
-    }
+
+    team_name_to_id = {team.name: team.id for team in teams}
+
+    team_counts = defaultdict(
+        lambda: {
+            "repo_count": 0,
+            "baseline_compliant_count": 0,
+            "standard_compliant_count": 0,
+            "exemplar_compliant_count": 0,
+        }
+    )
+
+    for repo in repositories:
+        maturity_level = repo.maturity_level
+        team_ids_for_repository = {
+            team_name_to_id[owner_name]
+            for owner_name in repo.authorative_team_owners
+            if owner_name in team_name_to_id
+        }
+
+        for team_id in team_ids_for_repository:
+            team_counts[team_id]["repo_count"] += 1
+            if maturity_level >= 1:
+                team_counts[team_id]["baseline_compliant_count"] += 1
+            if maturity_level >= 2:
+                team_counts[team_id]["standard_compliant_count"] += 1
+            if maturity_level >= 3:
+                team_counts[team_id]["exemplar_compliant_count"] += 1
+
+    team_counts = {team.id: team_counts[team.id] for team in teams}
 
     return render_template(
         "projects/repository_standards/pages/teams.html",
         teams=teams,
-        team_repository_counts=team_repository_counts,
-        team_baseline_compliant_counts=team_baseline_compliant_counts,
-        team_standard_compliant_counts=team_standard_compliant_counts,
-        team_exemplar_compliant_counts=team_exemplar_compliant_counts,
+        team_counts=team_counts,
     )
 
 

--- a/app/projects/repository_standards/routes/main.py
+++ b/app/projects/repository_standards/routes/main.py
@@ -79,7 +79,7 @@ def business_units_owner(owner_id: str):
     filtrated_repositories = [
         repo
         for repo in repositories
-        if owner.name in repo.authorative_business_unit_owners
+        if owner.name in repo.authoritative_business_unit_owners
     ]
 
     return render_template(
@@ -121,7 +121,7 @@ def teams():
         maturity_level = repo.maturity_level
         team_ids_for_repository = {
             team_name_to_id[owner_name]
-            for owner_name in repo.authorative_team_owners
+            for owner_name in repo.authoritative_team_owners
             if owner_name in team_name_to_id
         }
 
@@ -156,7 +156,7 @@ def teams_owner(owner_id: str):
     repositories = repository_compliance_service.get_all_repositories()
 
     filtrated_repositories = [
-        repo for repo in repositories if owner.name in repo.authorative_team_owners
+        repo for repo in repositories if owner.name in repo.authoritative_team_owners
     ]
 
     return render_template(
@@ -278,8 +278,8 @@ def unowned_repositories():
     filtrated_repositories = [
         repo
         for repo in repositories
-        if not repo.authorative_business_unit_owners
-        and not repo.authorative_team_owners
+        if not repo.authoritative_business_unit_owners
+        and not repo.authoritative_team_owners
     ]
 
     return render_template(

--- a/app/projects/repository_standards/services/asset_service.py
+++ b/app/projects/repository_standards/services/asset_service.py
@@ -30,11 +30,11 @@ class AssetService:
         owner_has_other_access = bool(owner_to_filter_by in repository.owner_names)
         no_repository_admins = len(repository.admin_owner_names) == 0
 
-        has_authorative_ownership = bool(
+        has_authoritative_ownership = bool(
             owner_has_admin_access or (owner_has_other_access and no_repository_admins)
         )
 
-        return has_authorative_ownership
+        return has_authoritative_ownership
 
     def update_relationships_with_owner(
         self, asset: Asset, owner: OwnerView, relationship_type: str

--- a/app/projects/repository_standards/services/repository_compliance_service.py
+++ b/app/projects/repository_standards/services/repository_compliance_service.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, TypedDict
 from collections import defaultdict
 from urllib.parse import quote
 
@@ -21,6 +21,12 @@ from app.projects.repository_standards.services.asset_service import (
 
 
 class RepositoryComplianceService:
+    class OwnerComplianceCounts(TypedDict):
+        repo_count: int
+        baseline_compliant_count: int
+        standard_compliant_count: int
+        exemplar_compliant_count: int
+
     def __init__(self, asset_service: AssetService):
         self.__asset_service = asset_service
 
@@ -83,7 +89,9 @@ class RepositoryComplianceService:
             description=repository.data.basic.description,
         )
 
-    def aggregate_owner_counts(self, entities: List[Owner]) -> dict:
+    def aggregate_owner_counts(
+        self, entities: List[Owner]
+    ) -> dict[str, OwnerComplianceCounts]:
         repositories = self.get_all_repositories()
         name_to_id = {entity.name: entity.id for entity in entities}
 
@@ -94,7 +102,9 @@ class RepositoryComplianceService:
         else:
             raise ValueError(f"Unrecognised owner type: {entities[0].type.name if entities else 'empty list'}")
 
-        counts = defaultdict(
+        counts: defaultdict[
+            str, RepositoryComplianceService.OwnerComplianceCounts
+        ] = defaultdict(
             lambda: {
                 "repo_count": 0,
                 "baseline_compliant_count": 0,

--- a/app/projects/repository_standards/services/repository_compliance_service.py
+++ b/app/projects/repository_standards/services/repository_compliance_service.py
@@ -1,4 +1,5 @@
 from typing import List
+from collections import defaultdict
 from urllib.parse import quote
 
 from flask import g
@@ -9,6 +10,7 @@ from app.projects.repository_standards.config.repository_compliance_config impor
 from app.projects.repository_standards.models.repository_compliance import (
     RepositoryComplianceReportView,
 )
+from app.projects.repository_standards.db_models import Owner
 from app.projects.repository_standards.repositories.asset_repository import (
     RepositoryView,
 )
@@ -80,6 +82,46 @@ class RepositoryComplianceService:
             checks=checks,
             description=repository.data.basic.description,
         )
+
+    def aggregate_owner_counts(self, entities: List[Owner]) -> dict:
+        repositories = self.get_all_repositories()
+        name_to_id = {entity.name: entity.id for entity in entities}
+
+        if entities and entities[0].type.name == "BUSINESS_UNIT":
+            owner_field_name = "authoritative_business_unit_owners"
+        elif entities and entities[0].type.name == "TEAM":
+            owner_field_name = "authoritative_team_owners"
+        else:
+            raise ValueError(f"Unrecognised owner type: {entities[0].type.name if entities else 'empty list'}")
+
+        counts = defaultdict(
+            lambda: {
+                "repo_count": 0,
+                "baseline_compliant_count": 0,
+                "standard_compliant_count": 0,
+                "exemplar_compliant_count": 0,
+            }
+        )
+
+        for repo in repositories:
+            maturity_level = repo.maturity_level
+            owner_names = getattr(repo, owner_field_name, [])
+            entity_ids_for_repository = {
+                name_to_id[owner_name]
+                for owner_name in owner_names
+                if owner_name in name_to_id
+            }
+
+            for entity_id in entity_ids_for_repository:
+                counts[entity_id]["repo_count"] += 1
+                if maturity_level >= 1:
+                    counts[entity_id]["baseline_compliant_count"] += 1
+                if maturity_level >= 2:
+                    counts[entity_id]["standard_compliant_count"] += 1
+                if maturity_level >= 3:
+                    counts[entity_id]["exemplar_compliant_count"] += 1
+
+        return {entity.id: counts[entity.id] for entity in entities}
 
     def get_all_repositories(self) -> List[RepositoryComplianceReportView]:
         repositories_compliance_reports = []

--- a/app/projects/repository_standards/services/repository_compliance_service.py
+++ b/app/projects/repository_standards/services/repository_compliance_service.py
@@ -22,10 +22,10 @@ class RepositoryComplianceService:
     def __init__(self, asset_service: AssetService):
         self.__asset_service = asset_service
 
-    def __get_authorative_owners(
+    def __get_authoritative_owners(
         self, repository: RepositoryView, owners_to_check: List[str]
     ) -> List[str]:
-        authorative_owners = [
+        authoritative_owners = [
             owner
             for owner in owners_to_check
             if self.__asset_service.is_owner_authoritative_for_repository(
@@ -33,20 +33,20 @@ class RepositoryComplianceService:
             )
         ]
 
-        return authorative_owners
+        return authoritative_owners
 
     def __get_repository_compliance_report(
         self,
         repository: RepositoryView,
     ) -> RepositoryComplianceReportView:
-        authorative_business_unit_owners = self.__get_authorative_owners(
+        authoritative_business_unit_owners = self.__get_authoritative_owners(
             repository, repository.business_unit_owners_names
         )
-        authorative_team_owners = self.__get_authorative_owners(
+        authoritative_team_owners = self.__get_authoritative_owners(
             repository, repository.team_owners_names
         )
         checks = get_all_compliance_checks(
-            repository, authorative_business_unit_owners or authorative_team_owners
+            repository, authoritative_business_unit_owners or authoritative_team_owners
         )
 
         compliance_status = (
@@ -74,8 +74,8 @@ class RepositoryComplianceService:
         return RepositoryComplianceReportView(
             name=repository.name,
             compliance_status=compliance_status,
-            authorative_business_unit_owners=authorative_business_unit_owners,
-            authorative_team_owners=authorative_team_owners,
+            authoritative_business_unit_owners=authoritative_business_unit_owners,
+            authoritative_team_owners=authoritative_team_owners,
             maturity_level=maturity_level,
             checks=checks,
             description=repository.data.basic.description,

--- a/app/templates/projects/repository_standards/pages/business_unit.html
+++ b/app/templates/projects/repository_standards/pages/business_unit.html
@@ -85,7 +85,7 @@
           <td class="govuk-table__cell">
             <img src={% if repository.maturity_level > 0 %}"/assets/images/{{ repository.maturity_level }}-badge.svg"{% else %}"/assets/images/fail-badge.svg"{% endif %}  alt="{{ repository.maturity_level }}" />
           </td>
-          <td class="govuk-table__cell">{{ repository.authorative_team_owners | join(",") or None }}</td>
+          <td class="govuk-table__cell">{{ repository.authoritative_team_owners | join(",") or None }}</td>
           <td class="govuk-table__cell"><a href="/repository-standards/{{ repository.name }}" rel="noreferrer noopener" class="govuk-link">View Compliance Report</a></td>
         </tr>
         {% endfor %}

--- a/app/templates/projects/repository_standards/pages/business_unit.html
+++ b/app/templates/projects/repository_standards/pages/business_unit.html
@@ -16,45 +16,24 @@
   } %}
   {{ govukBreadcrumbs(breadcrumbs) }}
 
-  <h1 class="govuk-heading-xl">{{ owner.name }}</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ owner.name }}</h1>
+    </div>
 
+    <div class="govuk-grid-column-one-third">
+      <p class="govuk-body govuk-!-text-align-right govuk-!-margin-top-4"><a class="govuk-link " href="/repository-standards/business-units/{{ owner.id }}/edit">Edit</a></p>
+    </div>
+  </div>
   <section class="govuk-summary-list govuk-!-margin-bottom-6">
-    <h2 class="govuk-heading-l">Summary Statistics</h2>
-
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Total Repositories</dt>
-      <dd class="govuk-summary-list__value">{{ repositories | length }}</dd>
-    </div>
-
-    {% set compliance_percentage = ((baseline_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Baseline Compliant</dt>
-      <dd class="govuk-summary-list__value">
-        {{ compliance_tag(compliance_percentage, baseline_maturity_level_repositories | length) }}
-      </dd>
-    </div>
-
-    {% set compliance_percentage = ((standard_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Standard Compliant</dt>
-      <dd class="govuk-summary-list__value">
-        {{ compliance_tag(compliance_percentage, standard_maturity_level_repositories | length) }}
-      </dd>
-    </div>
-
-    {% set compliance_percentage = ((exemplar_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Exemplar Compliant</dt>
-      <dd class="govuk-summary-list__value">
-        {{ compliance_tag(compliance_percentage, exemplar_maturity_level_repositories | length) }}
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">GitHub Teams<br /><p class="govuk-body-s govuk-!-margin-bottom-1">Teams are used to determine repository ownership</p></dt>
+      <dt class="govuk-summary-list__key">
+        GitHub Teams
+        <p class="govuk-body-s govuk-!-margin-bottom-1">GitHub teams are used to determine repository ownership</p>
+      </dt>
       <dd class="govuk-summary-list__value">
         {% for team in owner.config.teams %}
-        <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>
+        <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>{% if not loop.last %}, {% endif %}
         {% endfor %}
       </dd>
     </div>

--- a/app/templates/projects/repository_standards/pages/business_unit.html
+++ b/app/templates/projects/repository_standards/pages/business_unit.html
@@ -1,4 +1,5 @@
 {% extends "shared/components/base.html" %}
+{% from "shared/components/macros.html" import compliance_tag %}
 
 {% block pageTitle %}
   {{ owner.name }}
@@ -29,16 +30,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Baseline Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ baseline_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, baseline_maturity_level_repositories | length) }}
       </dd>
     </div>
 
@@ -46,16 +38,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Standard Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ standard_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, standard_maturity_level_repositories | length) }}
       </dd>
     </div>
 
@@ -63,16 +46,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Exemplar Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ exemplar_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, exemplar_maturity_level_repositories | length) }}
       </dd>
     </div>
 

--- a/app/templates/projects/repository_standards/pages/business_unit.html
+++ b/app/templates/projects/repository_standards/pages/business_unit.html
@@ -1,5 +1,4 @@
 {% extends "shared/components/base.html" %}
-{% from "shared/components/macros.html" import compliance_tag %}
 
 {% block pageTitle %}
   {{ owner.name }}
@@ -16,24 +15,72 @@
   } %}
   {{ govukBreadcrumbs(breadcrumbs) }}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{ owner.name }}</h1>
+  <h1 class="govuk-heading-xl">{{ owner.name }}</h1>
+
+  <section class="govuk-summary-list govuk-!-margin-bottom-6">
+    <h2 class="govuk-heading-l">Summary Statistics</h2>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Total Repositories</dt>
+      <dd class="govuk-summary-list__value">{{ repositories | length }}</dd>
     </div>
 
-    <div class="govuk-grid-column-one-third">
-      <p class="govuk-body govuk-!-text-align-right govuk-!-margin-top-4"><a class="govuk-link " href="/repository-standards/business-units/{{ owner.id }}/edit">Edit</a></p>
-    </div>
-  </div>
-  <section class="govuk-summary-list govuk-!-margin-bottom-6">
+    {% set compliance_percentage = ((baseline_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        GitHub Teams
-        <p class="govuk-body-s govuk-!-margin-bottom-1">GitHub teams are used to determine repository ownership</p>
-      </dt>
+      <dt class="govuk-summary-list__key">Baseline Compliant</dt>
+      <dd class="govuk-summary-list__value">
+        <span class="
+                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
+                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
+                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
+                     {% else %} govuk-tag govuk-tag--green-dark
+                     {% endif %}
+                     ">
+          {{ baseline_maturity_level_repositories | length }}
+          ({{ compliance_percentage | round | int }}%)
+        </span>
+      </dd>
+    </div>
+
+    {% set compliance_percentage = ((standard_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Standard Compliant</dt>
+      <dd class="govuk-summary-list__value">
+        <span class="
+                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
+                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
+                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
+                     {% else %} govuk-tag govuk-tag--green-dark
+                     {% endif %}
+                     ">
+          {{ standard_maturity_level_repositories | length }}
+          ({{ compliance_percentage | round | int }}%)
+        </span>
+      </dd>
+    </div>
+
+    {% set compliance_percentage = ((exemplar_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Exemplar Compliant</dt>
+      <dd class="govuk-summary-list__value">
+        <span class="
+                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
+                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
+                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
+                     {% else %} govuk-tag govuk-tag--green-dark
+                     {% endif %}
+                     ">
+          {{ exemplar_maturity_level_repositories | length }}
+          ({{ compliance_percentage | round | int }}%)
+        </span>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">GitHub Teams<br /><p class="govuk-body-s govuk-!-margin-bottom-1">Teams are used to determine repository ownership</p></dt>
       <dd class="govuk-summary-list__value">
         {% for team in owner.config.teams %}
-        <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>{% if not loop.last %}, {% endif %}
+        <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>
         {% endfor %}
       </dd>
     </div>

--- a/app/templates/projects/repository_standards/pages/business_units.html
+++ b/app/templates/projects/repository_standards/pages/business_units.html
@@ -38,6 +38,7 @@
     </div>
   </section>
 
+
   <section>
     <h2 class="govuk-heading-l">Business Units Summary Statistics</h2>
     {% if not business_unit_names %}
@@ -47,7 +48,7 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header" aria-sort="ascending">
-            Business Units
+            Business Unit
           </th>
           <th scope="col" class="govuk-table__header" aria-sort="ascending">
            Total Repositories

--- a/app/templates/projects/repository_standards/pages/business_units.html
+++ b/app/templates/projects/repository_standards/pages/business_units.html
@@ -66,13 +66,13 @@
             <a class="govuk-link govuk-!-font-weight-bold" href="/repository-standards/business-units/{{ business_unit.id }}">{{ business_unit.name }}</a>
           </td>
           <td class="govuk-table__cell">{{ total_repositories }}</td>
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell" data-sort-value="{{ (baseline_compliance_percentage * 10000 + baseline_compliant_count) | int }}">
             {{ compliance_tag(baseline_compliance_percentage, baseline_compliant_count) }}
           </td>
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell" data-sort-value="{{ (standard_compliance_percentage * 10000 + standard_compliant_count) | int }}">
             {{ compliance_tag(standard_compliance_percentage, standard_compliant_count) }}
           </td>
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell" data-sort-value="{{ (exemplar_compliance_percentage * 10000 + exemplar_compliant_count) | int }}">
             {{ compliance_tag(exemplar_compliance_percentage, exemplar_compliant_count) }}
           </td>
         </tr>

--- a/app/templates/projects/repository_standards/pages/business_units.html
+++ b/app/templates/projects/repository_standards/pages/business_units.html
@@ -25,19 +25,6 @@
 
   <h1 class="govuk-heading-xl">Business Units</h1>
   <p class="govuk-body-s">View compliance reports for Business Units within the Ministry of Justice.</p>
-  <section>
-    <div class="govuk-grid-row">
-      {% for business_unit in business_unit_names %}
-      <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-          <a class="govuk-link" href="/repository-standards/business-units/{{ business_unit.id }}">{{ business_unit.name }}</a>
-        </h2>
-        <p class="govuk-body-s">View the compliance status for all active, public repositories owned by {{ business_unit.name }}.</p>
-      </div>
-      {% endfor %}
-    </div>
-  </section>
-
 
   <section>
     <h2 class="govuk-heading-l">Business Units Summary Statistics</h2>
@@ -94,6 +81,5 @@
     </table>
     {% endif %}
   </section>
-
 
 {% endblock %}

--- a/app/templates/projects/repository_standards/pages/business_units.html
+++ b/app/templates/projects/repository_standards/pages/business_units.html
@@ -1,5 +1,5 @@
 {% extends "shared/components/base.html" %}
-{% from "shared/components/macros.html" import compliance_tag %}
+{% from "shared/components/macros.html" import compliance_tag, compliance_sort_value %}
 
 {% block pageTitle %}
     Business Units
@@ -66,13 +66,13 @@
             <a class="govuk-link govuk-!-font-weight-bold" href="/repository-standards/business-units/{{ business_unit.id }}">{{ business_unit.name }}</a>
           </td>
           <td class="govuk-table__cell">{{ total_repositories }}</td>
-          <td class="govuk-table__cell" data-sort-value="{{ (baseline_compliance_percentage * 10000 + baseline_compliant_count) | int }}">
+          <td class="govuk-table__cell" data-sort-value="{{ compliance_sort_value(baseline_compliance_percentage, baseline_compliant_count) }}">
             {{ compliance_tag(baseline_compliance_percentage, baseline_compliant_count) }}
           </td>
-          <td class="govuk-table__cell" data-sort-value="{{ (standard_compliance_percentage * 10000 + standard_compliant_count) | int }}">
+          <td class="govuk-table__cell" data-sort-value="{{ compliance_sort_value(standard_compliance_percentage, standard_compliant_count) }}">
             {{ compliance_tag(standard_compliance_percentage, standard_compliant_count) }}
           </td>
-          <td class="govuk-table__cell" data-sort-value="{{ (exemplar_compliance_percentage * 10000 + exemplar_compliant_count) | int }}">
+          <td class="govuk-table__cell" data-sort-value="{{ compliance_sort_value(exemplar_compliance_percentage, exemplar_compliant_count) }}">
             {{ compliance_tag(exemplar_compliance_percentage, exemplar_compliant_count) }}
           </td>
         </tr>

--- a/app/templates/projects/repository_standards/pages/business_units.html
+++ b/app/templates/projects/repository_standards/pages/business_units.html
@@ -1,4 +1,5 @@
 {% extends "shared/components/base.html" %}
+{% from "shared/components/macros.html" import compliance_tag %}
 
 {% block pageTitle %}
     Business Units
@@ -36,5 +37,62 @@
       {% endfor %}
     </div>
   </section>
+
+  <section>
+    <h2 class="govuk-heading-l">Business Units Summary Statistics</h2>
+    {% if not business_unit_names %}
+    <p class="govuk-body-s">No business units.</p>
+    {% else %}
+    <table class="govuk-table" data-module="moj-sortable-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+            Business Units
+          </th>
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+           Total Repositories
+          </th>
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+           Baseline Compliant
+          </th>
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+           Standard Compliant
+          </th>
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+           Exemplar Compliant
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for business_unit in business_unit_names %}
+        {% set counts = business_unit_counts.get(business_unit.id, {}) %}
+        {% set total_repositories = counts.get("repo_count", 0) %}
+        {% set baseline_compliant_count = counts.get("baseline_compliant_count", 0) %}
+        {% set standard_compliant_count = counts.get("standard_compliant_count", 0) %}
+        {% set exemplar_compliant_count = counts.get("exemplar_compliant_count", 0) %}
+        {% set baseline_compliance_percentage = (baseline_compliant_count / total_repositories) * 100 if total_repositories else 0 %}
+        {% set standard_compliance_percentage = (standard_compliant_count / total_repositories) * 100 if total_repositories else 0 %}
+        {% set exemplar_compliance_percentage = (exemplar_compliant_count / total_repositories) * 100 if total_repositories else 0 %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <a class="govuk-link govuk-!-font-weight-bold" href="/repository-standards/business-units/{{ business_unit.id }}">{{ business_unit.name }}</a>
+          </td>
+          <td class="govuk-table__cell">{{ total_repositories }}</td>
+          <td class="govuk-table__cell">
+            {{ compliance_tag(baseline_compliance_percentage, baseline_compliant_count) }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ compliance_tag(standard_compliance_percentage, standard_compliant_count) }}
+          </td>
+          <td class="govuk-table__cell">
+            {{ compliance_tag(exemplar_compliance_percentage, exemplar_compliant_count) }}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+  </section>
+
 
 {% endblock %}

--- a/app/templates/projects/repository_standards/pages/repositories.html
+++ b/app/templates/projects/repository_standards/pages/repositories.html
@@ -1,4 +1,5 @@
 {% extends "shared/components/base.html" %}
+{% from "shared/components/macros.html" import compliance_tag %}
 
 {% block pageTitle %}
     Repository Standards
@@ -36,16 +37,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Baseline Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ baseline_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, baseline_maturity_level_repositories | length) }}
       </dd>
     </div>
 
@@ -53,16 +45,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Standard Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ standard_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, standard_maturity_level_repositories | length) }}
       </dd>
     </div>
 
@@ -70,16 +53,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Exemplar Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ exemplar_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, exemplar_maturity_level_repositories | length) }}
       </dd>
     </div>
 

--- a/app/templates/projects/repository_standards/pages/repositories.html
+++ b/app/templates/projects/repository_standards/pages/repositories.html
@@ -84,7 +84,7 @@
           <td class="govuk-table__cell">
             <img src={% if repository.maturity_level > 0 %}"/assets/images/{{ repository.maturity_level }}-badge.svg"{% else %}"/assets/images/fail-badge.svg"{% endif %}  alt="{{ repository.maturity_level }}" />
           </td>
-          <td class="govuk-table__cell">{{ repository.authorative_business_unit_owners | join(",") or None }}</td>
+          <td class="govuk-table__cell">{{ repository.authoritative_business_unit_owners | join(",") or None }}</td>
           <td class="govuk-table__cell"><a href="/repository-standards/{{ repository.name }}" rel="noreferrer noopener" class="govuk-link">View Compliance Report</a></td>
         </tr>
         {% endfor %}

--- a/app/templates/projects/repository_standards/pages/repository.html
+++ b/app/templates/projects/repository_standards/pages/repository.html
@@ -20,13 +20,13 @@
   <section class="govuk-summary-list govuk-!-margin-bottom-6">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Owner</dt>
-      <dd class="govuk-summary-list__value">{{ repository.authorative_business_unit_owners | join(",") or None }}</dd>
+      <dd class="govuk-summary-list__value">{{ repository.authoritative_business_unit_owners | join(",") or None }}</dd>
     </div>
 
-    {% if repository.authorative_team_owners %}
+    {% if repository.authoritative_team_owners %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Team</dt>
-      <dd class="govuk-summary-list__value">{{ repository.authorative_team_owners | join(",") }}</dd>
+      <dd class="govuk-summary-list__value">{{ repository.authoritative_team_owners | join(",") }}</dd>
     </div>
     {% endif %}
 

--- a/app/templates/projects/repository_standards/pages/team.html
+++ b/app/templates/projects/repository_standards/pages/team.html
@@ -1,5 +1,4 @@
 {% extends "shared/components/base.html" %}
-{% from "shared/components/macros.html" import compliance_tag %}
 
 {% block pageTitle %}
   {{ owner.name }}
@@ -27,17 +26,73 @@
     </div>
   </div>
   <section class="govuk-summary-list govuk-!-margin-bottom-6">
+    <h2 class="govuk-heading-l">Summary Statistics</h2>
+
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        GitHub Teams
-        <p class="govuk-body-s govuk-!-margin-bottom-1">GitHub teams are used to determine repository ownership</p>
-      </dt>
+      <dt class="govuk-summary-list__key">Total Repositories</dt>
+      <dd class="govuk-summary-list__value">{{ repositories | length }}</dd>
+    </div>
+
+    {% set compliance_percentage = ((baseline_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Baseline Compliant</dt>
+      <dd class="govuk-summary-list__value">
+        <span class="
+                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
+                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
+                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
+                     {% else %} govuk-tag govuk-tag--green-dark
+                     {% endif %}
+                     ">
+          {{ baseline_maturity_level_repositories | length }}
+          ({{ compliance_percentage | round | int }}%)
+        </span>
+      </dd>
+    </div>
+
+    {% set compliance_percentage = ((standard_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Standard Compliant</dt>
+      <dd class="govuk-summary-list__value">
+        <span class="
+                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
+                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
+                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
+                     {% else %} govuk-tag govuk-tag--green-dark
+                     {% endif %}
+                     ">
+          {{ standard_maturity_level_repositories | length }}
+          ({{ compliance_percentage | round | int }}%)
+        </span>
+      </dd>
+    </div>
+
+    {% set compliance_percentage = ((exemplar_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Exemplar Compliant</dt>
+      <dd class="govuk-summary-list__value">
+        <span class="
+                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
+                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
+                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
+                     {% else %} govuk-tag govuk-tag--green-dark
+                     {% endif %}
+                     ">
+          {{ exemplar_maturity_level_repositories | length }}
+          ({{ compliance_percentage | round | int }}%)
+        </span>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">GitHub Teams<br /><p class="govuk-body-s govuk-!-margin-bottom-1">Teams are used to determine repository ownership</p></dt>
       <dd class="govuk-summary-list__value">
         {% for team in owner.config.teams %}
-        <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>{% if not loop.last %}, {% endif %}
+        <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>
         {% endfor %}
       </dd>
     </div>
+
   </section>
 
   <section>

--- a/app/templates/projects/repository_standards/pages/team.html
+++ b/app/templates/projects/repository_standards/pages/team.html
@@ -72,7 +72,7 @@
           <td class="govuk-table__cell">
             <img src={% if repository.maturity_level > 0 %}"/assets/images/{{ repository.maturity_level }}-badge.svg"{% else %}"/assets/images/fail-badge.svg"{% endif %}  alt="{{ repository.maturity_level }}" />
           </td>
-          {% set owners = repository.authorative_business_unit_owners + repository.authorative_team_owners  %}
+          {% set owners = repository.authoritative_business_unit_owners + repository.authoritative_team_owners  %}
           <td class="govuk-table__cell">{{ owners | join(",") or None }}</td>
           <td class="govuk-table__cell"><a href="/repository-standards/{{ repository.name }}" rel="noreferrer noopener" class="govuk-link">View Compliance Report</a></td>
         </tr>

--- a/app/templates/projects/repository_standards/pages/team.html
+++ b/app/templates/projects/repository_standards/pages/team.html
@@ -30,16 +30,12 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         GitHub Teams
-        <p class="govuk-body-s govuk-!-margin-bottom-1">Teams are used to determine repository ownership</p>
+        <p class="govuk-body-s govuk-!-margin-bottom-1">GitHub teams are used to determine repository ownership</p>
       </dt>
       <dd class="govuk-summary-list__value">
-        <ul class="govuk-list">
-          {% for team in owner.config.teams %}
-          <li>
-            <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>
-          </li>
-          {% endfor %}
-        </ul>
+        {% for team in owner.config.teams %}
+        <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>{% if not loop.last %}, {% endif %}
+        {% endfor %}
       </dd>
     </div>
   </section>

--- a/app/templates/projects/repository_standards/pages/team.html
+++ b/app/templates/projects/repository_standards/pages/team.html
@@ -27,46 +27,21 @@
     </div>
   </div>
   <section class="govuk-summary-list govuk-!-margin-bottom-6">
-    <h2 class="govuk-heading-l">Summary Statistics</h2>
-
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Total Repositories</dt>
-      <dd class="govuk-summary-list__value">{{ repositories | length }}</dd>
-    </div>
-
-    {% set compliance_percentage = ((baseline_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Baseline Compliant</dt>
+      <dt class="govuk-summary-list__key">
+        GitHub Teams
+        <p class="govuk-body-s govuk-!-margin-bottom-1">Teams are used to determine repository ownership</p>
+      </dt>
       <dd class="govuk-summary-list__value">
-        {{ compliance_tag(compliance_percentage, baseline_maturity_level_repositories | length) }}
+        <ul class="govuk-list">
+          {% for team in owner.config.teams %}
+          <li>
+            <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>
+          </li>
+          {% endfor %}
+        </ul>
       </dd>
     </div>
-
-    {% set compliance_percentage = ((standard_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Standard Compliant</dt>
-      <dd class="govuk-summary-list__value">
-        {{ compliance_tag(compliance_percentage, standard_maturity_level_repositories | length) }}
-      </dd>
-    </div>
-
-    {% set compliance_percentage = ((exemplar_maturity_level_repositories | length) / (repositories | length)) * 100 if repositories else 0 %}
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Exemplar Compliant</dt>
-      <dd class="govuk-summary-list__value">
-        {{ compliance_tag(compliance_percentage, exemplar_maturity_level_repositories | length) }}
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">GitHub Teams<br /><p class="govuk-body-s govuk-!-margin-bottom-1">Teams are used to determine repository ownership</p></dt>
-      <dd class="govuk-summary-list__value">
-        {% for team in owner.config.teams %}
-        <a class="govuk-link" href="https://github.com/orgs/ministryofjustice/teams/{{ team }}" rel="noopener noreferrer" target="_blank">{{ team }}</a>
-        {% endfor %}
-      </dd>
-    </div>
-
   </section>
 
   <section>

--- a/app/templates/projects/repository_standards/pages/team.html
+++ b/app/templates/projects/repository_standards/pages/team.html
@@ -1,4 +1,5 @@
 {% extends "shared/components/base.html" %}
+{% from "shared/components/macros.html" import compliance_tag %}
 
 {% block pageTitle %}
   {{ owner.name }}
@@ -37,16 +38,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Baseline Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ baseline_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, baseline_maturity_level_repositories | length) }}
       </dd>
     </div>
 
@@ -54,16 +46,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Standard Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ standard_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, standard_maturity_level_repositories | length) }}
       </dd>
     </div>
 
@@ -71,16 +54,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Exemplar Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ exemplar_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, exemplar_maturity_level_repositories | length) }}
       </dd>
     </div>
 

--- a/app/templates/projects/repository_standards/pages/teams.html
+++ b/app/templates/projects/repository_standards/pages/teams.html
@@ -64,9 +64,7 @@
         {% set exemplar_compliance_percentage = (exemplar_compliant_count / total_repositories) * 100 if total_repositories else 0 %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-              <a class="govuk-link" href="/repository-standards/teams/{{ team.id }}">{{ team.name }}</a>
-            </h2>
+            <a class="govuk-link govuk-!-font-weight-bold" href="/repository-standards/teams/{{ team.id }}">{{ team.name }}</a>
           </td>
           <td class="govuk-table__cell">{{ total_repositories }}</td>
           <td class="govuk-table__cell">

--- a/app/templates/projects/repository_standards/pages/teams.html
+++ b/app/templates/projects/repository_standards/pages/teams.html
@@ -24,19 +24,73 @@
 
   <h1 class="govuk-heading-xl">Teams</h1>
   <p class="govuk-body-s">
-    View compliance reports for Teams within the Ministry of Justice or <a class="govuk-link govuk-link--no-underline" href="/repository-standards/teams/add-team">Add a New Team</a>.</p>
+    View compliance reports for Teams within the Ministry of Justice or <a class="govuk-link govuk-link--no-underline" href="/repository-standards/teams/add-team">Add a New Team</a>.
+  </p>
 
   <section>
-    <div class="govuk-grid-row">
-      {% for team in teams %}
-      <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
-          <a class="govuk-link" href="/repository-standards/teams/{{ team.id }}">{{ team.name }}</a>
-        </h2>
-        <p class="govuk-body-s">View the compliance status for all active, public repositories owned by {{ team.name }}.</p>
-      </div>
-      {% endfor %}
-    </div>
+    <h2 class="govuk-heading-l">Teams Summary Statistics</h2>
+    {% if not teams %}
+    <p class="govuk-body-s">No teams.</p>
+    {% else %}
+    <table class="govuk-table" data-module="moj-sortable-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+            Team
+          </th>
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+           Total Repositories
+          </th>
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+           Baseline Compliant
+          </th>
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+           Standard Compliant
+          </th>
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">
+           Exemplar Compliant
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for team in teams %}
+        {% set total_repositories = team_repository_counts.get(team.id, 0) %}
+        {% set baseline_compliant_count = team_baseline_compliant_counts.get(team.id, 0) %}
+        {% set standard_compliant_count = team_standard_compliant_counts.get(team.id, 0) %}
+        {% set exemplar_compliant_count = team_exemplar_compliant_counts.get(team.id, 0) %}
+        {% set baseline_compliance_percentage = (baseline_compliant_count / total_repositories) * 100 if total_repositories else 0 %}
+        {% set standard_compliance_percentage = (standard_compliant_count / total_repositories) * 100 if total_repositories else 0 %}
+        {% set exemplar_compliance_percentage = (exemplar_compliant_count / total_repositories) * 100 if total_repositories else 0 %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
+              <a class="govuk-link" href="/repository-standards/teams/{{ team.id }}">{{ team.name }}</a>
+            </h2>
+          </td>
+          <td class="govuk-table__cell">{{ total_repositories }}</td>
+          <td class="govuk-table__cell">
+            <span class="{% if baseline_compliance_percentage < 60 %} govuk-tag govuk-tag--red{% elif baseline_compliance_percentage < 80 %} govuk-tag govuk-tag--yellow{% elif baseline_compliance_percentage < 100 %} govuk-tag govuk-tag--green{% else %} govuk-tag govuk-tag--green-dark{% endif %}">
+              {{ baseline_compliant_count }}
+              ({{ baseline_compliance_percentage | round | int }}%)
+            </span>
+          </td>
+          <td class="govuk-table__cell">
+            <span class="{% if standard_compliance_percentage < 60 %} govuk-tag govuk-tag--red{% elif standard_compliance_percentage < 80 %} govuk-tag govuk-tag--yellow{% elif standard_compliance_percentage < 100 %} govuk-tag govuk-tag--green{% else %} govuk-tag govuk-tag--green-dark{% endif %}">
+              {{ standard_compliant_count }}
+              ({{ standard_compliance_percentage | round | int }}%)
+            </span>
+          </td>
+          <td class="govuk-table__cell">
+            <span class="{% if exemplar_compliance_percentage < 60 %} govuk-tag govuk-tag--red{% elif exemplar_compliance_percentage < 80 %} govuk-tag govuk-tag--yellow{% elif exemplar_compliance_percentage < 100 %} govuk-tag govuk-tag--green{% else %} govuk-tag govuk-tag--green-dark{% endif %}">
+              {{ exemplar_compliant_count }}
+              ({{ exemplar_compliance_percentage | round | int }}%)
+            </span>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
   </section>
 
 {% endblock %}

--- a/app/templates/projects/repository_standards/pages/teams.html
+++ b/app/templates/projects/repository_standards/pages/teams.html
@@ -68,13 +68,13 @@
             <a class="govuk-link govuk-!-font-weight-bold" href="/repository-standards/teams/{{ team.id }}">{{ team.name }}</a>
           </td>
           <td class="govuk-table__cell">{{ total_repositories }}</td>
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell" data-sort-value="{{ (baseline_compliance_percentage * 10000 + baseline_compliant_count) | int }}">
             {{ compliance_tag(baseline_compliance_percentage, baseline_compliant_count) }}
           </td>
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell" data-sort-value="{{ (standard_compliance_percentage * 10000 + standard_compliant_count) | int }}">
             {{ compliance_tag(standard_compliance_percentage, standard_compliant_count) }}
           </td>
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell" data-sort-value="{{ (exemplar_compliance_percentage * 10000 + exemplar_compliant_count) | int }}">
             {{ compliance_tag(exemplar_compliance_percentage, exemplar_compliant_count) }}
           </td>
         </tr>

--- a/app/templates/projects/repository_standards/pages/teams.html
+++ b/app/templates/projects/repository_standards/pages/teams.html
@@ -1,5 +1,5 @@
 {% extends "shared/components/base.html" %}
-{% from "shared/components/macros.html" import compliance_tag %}
+{% from "shared/components/macros.html" import compliance_tag, compliance_sort_value %}
 
 {% block pageTitle %}
     Teams
@@ -68,13 +68,13 @@
             <a class="govuk-link govuk-!-font-weight-bold" href="/repository-standards/teams/{{ team.id }}">{{ team.name }}</a>
           </td>
           <td class="govuk-table__cell">{{ total_repositories }}</td>
-          <td class="govuk-table__cell" data-sort-value="{{ (baseline_compliance_percentage * 10000 + baseline_compliant_count) | int }}">
+          <td class="govuk-table__cell" data-sort-value="{{ compliance_sort_value(baseline_compliance_percentage, baseline_compliant_count) }}">
             {{ compliance_tag(baseline_compliance_percentage, baseline_compliant_count) }}
           </td>
-          <td class="govuk-table__cell" data-sort-value="{{ (standard_compliance_percentage * 10000 + standard_compliant_count) | int }}">
+          <td class="govuk-table__cell" data-sort-value="{{ compliance_sort_value(standard_compliance_percentage, standard_compliant_count) }}">
             {{ compliance_tag(standard_compliance_percentage, standard_compliant_count) }}
           </td>
-          <td class="govuk-table__cell" data-sort-value="{{ (exemplar_compliance_percentage * 10000 + exemplar_compliant_count) | int }}">
+          <td class="govuk-table__cell" data-sort-value="{{ compliance_sort_value(exemplar_compliance_percentage, exemplar_compliant_count) }}">
             {{ compliance_tag(exemplar_compliance_percentage, exemplar_compliant_count) }}
           </td>
         </tr>

--- a/app/templates/projects/repository_standards/pages/teams.html
+++ b/app/templates/projects/repository_standards/pages/teams.html
@@ -1,4 +1,5 @@
 {% extends "shared/components/base.html" %}
+{% from "shared/components/macros.html" import compliance_tag %}
 
 {% block pageTitle %}
     Teams
@@ -68,22 +69,13 @@
           </td>
           <td class="govuk-table__cell">{{ total_repositories }}</td>
           <td class="govuk-table__cell">
-            <span class="{% if baseline_compliance_percentage < 60 %} govuk-tag govuk-tag--red{% elif baseline_compliance_percentage < 80 %} govuk-tag govuk-tag--yellow{% elif baseline_compliance_percentage < 100 %} govuk-tag govuk-tag--green{% else %} govuk-tag govuk-tag--green-dark{% endif %}">
-              {{ baseline_compliant_count }}
-              ({{ baseline_compliance_percentage | round | int }}%)
-            </span>
+            {{ compliance_tag(baseline_compliance_percentage, baseline_compliant_count) }}
           </td>
           <td class="govuk-table__cell">
-            <span class="{% if standard_compliance_percentage < 60 %} govuk-tag govuk-tag--red{% elif standard_compliance_percentage < 80 %} govuk-tag govuk-tag--yellow{% elif standard_compliance_percentage < 100 %} govuk-tag govuk-tag--green{% else %} govuk-tag govuk-tag--green-dark{% endif %}">
-              {{ standard_compliant_count }}
-              ({{ standard_compliance_percentage | round | int }}%)
-            </span>
+            {{ compliance_tag(standard_compliance_percentage, standard_compliant_count) }}
           </td>
           <td class="govuk-table__cell">
-            <span class="{% if exemplar_compliance_percentage < 60 %} govuk-tag govuk-tag--red{% elif exemplar_compliance_percentage < 80 %} govuk-tag govuk-tag--yellow{% elif exemplar_compliance_percentage < 100 %} govuk-tag govuk-tag--green{% else %} govuk-tag govuk-tag--green-dark{% endif %}">
-              {{ exemplar_compliant_count }}
-              ({{ exemplar_compliance_percentage | round | int }}%)
-            </span>
+            {{ compliance_tag(exemplar_compliance_percentage, exemplar_compliant_count) }}
           </td>
         </tr>
         {% endfor %}

--- a/app/templates/projects/repository_standards/pages/teams.html
+++ b/app/templates/projects/repository_standards/pages/teams.html
@@ -54,10 +54,11 @@
       </thead>
       <tbody class="govuk-table__body">
         {% for team in teams %}
-        {% set total_repositories = team_repository_counts.get(team.id, 0) %}
-        {% set baseline_compliant_count = team_baseline_compliant_counts.get(team.id, 0) %}
-        {% set standard_compliant_count = team_standard_compliant_counts.get(team.id, 0) %}
-        {% set exemplar_compliant_count = team_exemplar_compliant_counts.get(team.id, 0) %}
+        {% set counts = team_counts.get(team.id, {}) %}
+        {% set total_repositories = counts.get("repo_count", 0) %}
+        {% set baseline_compliant_count = counts.get("baseline_compliant_count", 0) %}
+        {% set standard_compliant_count = counts.get("standard_compliant_count", 0) %}
+        {% set exemplar_compliant_count = counts.get("exemplar_compliant_count", 0) %}
         {% set baseline_compliance_percentage = (baseline_compliant_count / total_repositories) * 100 if total_repositories else 0 %}
         {% set standard_compliance_percentage = (standard_compliant_count / total_repositories) * 100 if total_repositories else 0 %}
         {% set exemplar_compliance_percentage = (exemplar_compliant_count / total_repositories) * 100 if total_repositories else 0 %}

--- a/app/templates/projects/repository_standards/pages/teams.html
+++ b/app/templates/projects/repository_standards/pages/teams.html
@@ -1,7 +1,7 @@
 {% extends "shared/components/base.html" %}
 
 {% block pageTitle %}
-    Business Units
+    Teams
 {% endblock %}
 
 {% block content %}

--- a/app/templates/projects/repository_standards/pages/unowned_repositories.html
+++ b/app/templates/projects/repository_standards/pages/unowned_repositories.html
@@ -1,4 +1,5 @@
 {% extends "shared/components/base.html" %}
+{% from "shared/components/macros.html" import compliance_tag %}
 
 {% block pageTitle %}
     Repository Standards
@@ -36,16 +37,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Baseline Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ baseline_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, baseline_maturity_level_repositories | length) }}
       </dd>
     </div>
 
@@ -53,16 +45,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Standard Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ standard_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, standard_maturity_level_repositories | length) }}
       </dd>
     </div>
 
@@ -70,16 +53,7 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Exemplar Compliant</dt>
       <dd class="govuk-summary-list__value">
-        <span class="
-                     {% if compliance_percentage < 60 %} govuk-tag govuk-tag--red
-                     {% elif compliance_percentage < 80 %} govuk-tag govuk-tag--yellow
-                     {% elif compliance_percentage < 100 %} govuk-tag govuk-tag--green
-                     {% else %} govuk-tag govuk-tag--green-dark
-                     {% endif %}
-                     ">
-          {{ exemplar_maturity_level_repositories | length }}
-          ({{ compliance_percentage | round | int }}%)
-        </span>
+        {{ compliance_tag(compliance_percentage, exemplar_maturity_level_repositories | length) }}
       </dd>
     </div>
 

--- a/app/templates/projects/repository_standards/pages/unowned_repositories.html
+++ b/app/templates/projects/repository_standards/pages/unowned_repositories.html
@@ -83,7 +83,7 @@
           <td class="govuk-table__cell">
             <img src={% if repository.maturity_level > 0 %}"/assets/images/{{ repository.maturity_level }}-badge.svg"{% else %}"/assets/images/fail-badge.svg"{% endif %}  alt="{{ repository.maturity_level }}" />
           </td>
-          <td class="govuk-table__cell">{{ repository.authorative_business_unit_owners | join(",") or repository.authorative_team_owners | join(",") or None }}</td>
+          <td class="govuk-table__cell">{{ repository.authoritative_business_unit_owners | join(",") or repository.authoritative_team_owners | join(",") or None }}</td>
           <td class="govuk-table__cell"><a href="/repository-standards/{{ repository.name }}" rel="noreferrer noopener" class="govuk-link">View Compliance Report</a></td>
         </tr>
         {% endfor %}

--- a/app/templates/shared/components/macros.html
+++ b/app/templates/shared/components/macros.html
@@ -1,0 +1,7 @@
+{% macro compliance_tag(percentage, count) %}
+  {%- if percentage < 60 %}{% set tag_class = "govuk-tag govuk-tag--red" %}
+  {%- elif percentage < 80 %}{% set tag_class = "govuk-tag govuk-tag--yellow" %}
+  {%- elif percentage <= 100 %}{% set tag_class = "govuk-tag govuk-tag--green" %}
+  {%- endif %}
+  <span class="{{ tag_class }}">{{ count }} ({{ percentage | round | int }}%)</span>
+{%- endmacro %}

--- a/app/templates/shared/components/macros.html
+++ b/app/templates/shared/components/macros.html
@@ -5,3 +5,7 @@
   {%- endif %}
   <span class="{{ tag_class }}">{{ percentage | round | int }}% ({{ count }})</span>
 {%- endmacro %}
+
+{% macro compliance_sort_value(percentage, count) %}
+  {{- '%03d%08d' % (percentage | int, count) }}
+{%- endmacro %}

--- a/app/templates/shared/components/macros.html
+++ b/app/templates/shared/components/macros.html
@@ -3,5 +3,5 @@
   {%- elif percentage < 80 %}{% set tag_class = "govuk-tag govuk-tag--yellow" %}
   {%- elif percentage <= 100 %}{% set tag_class = "govuk-tag govuk-tag--green" %}
   {%- endif %}
-  <span class="{{ tag_class }}">{{ count }} ({{ percentage | round | int }}%)</span>
+  <span class="{{ tag_class }}">{{ percentage | round | int }}% ({{ count }})</span>
 {%- endmacro %}

--- a/test/test_app/test_routes/test_main.py
+++ b/test/test_app/test_routes/test_main.py
@@ -1,0 +1,91 @@
+import unittest
+from types import SimpleNamespace
+
+from app.projects.repository_standards.routes.main import aggregate_owner_counts
+
+
+class TestAggregateOwnerCounts(unittest.TestCase):
+    def test_aggregates_counts_by_owner_and_maturity(self):
+        entities = [
+            SimpleNamespace(id="team-a", name="Team A"),
+            SimpleNamespace(id="team-b", name="Team B"),
+            SimpleNamespace(id="team-c", name="Team C"),
+        ]
+
+        repositories = [
+            SimpleNamespace(
+                maturity_level=1,
+                authoritative_team_owners=["Team A", "Team B"],
+            ),
+            SimpleNamespace(
+                maturity_level=2,
+                authoritative_team_owners=["Team A", "Team A"],
+            ),
+            SimpleNamespace(
+                maturity_level=3,
+                authoritative_team_owners=["Team B", "Unknown Team"],
+            ),
+            SimpleNamespace(
+                maturity_level=0,
+                authoritative_team_owners=["Team A"],
+            ),
+        ]
+
+        result = aggregate_owner_counts(
+            entities,
+            repositories,
+            "authoritative_team_owners",
+        )
+
+        self.assertEqual(
+            result["team-a"],
+            {
+                "repo_count": 3,
+                "baseline_compliant_count": 2,
+                "standard_compliant_count": 1,
+                "exemplar_compliant_count": 0,
+            },
+        )
+        self.assertEqual(
+            result["team-b"],
+            {
+                "repo_count": 2,
+                "baseline_compliant_count": 2,
+                "standard_compliant_count": 1,
+                "exemplar_compliant_count": 1,
+            },
+        )
+        self.assertEqual(
+            result["team-c"],
+            {
+                "repo_count": 0,
+                "baseline_compliant_count": 0,
+                "standard_compliant_count": 0,
+                "exemplar_compliant_count": 0,
+            },
+        )
+
+    def test_supports_different_owner_field_names(self):
+        entities = [SimpleNamespace(id="bu-a", name="Business Unit A")]
+        repositories = [
+            SimpleNamespace(
+                maturity_level=3,
+                authoritative_business_unit_owners=["Business Unit A"],
+            )
+        ]
+
+        result = aggregate_owner_counts(
+            entities,
+            repositories,
+            "authoritative_business_unit_owners",
+        )
+
+        self.assertEqual(
+            result["bu-a"],
+            {
+                "repo_count": 1,
+                "baseline_compliant_count": 1,
+                "standard_compliant_count": 1,
+                "exemplar_compliant_count": 1,
+            },
+        )

--- a/test/test_app/test_routes/test_main.py
+++ b/test/test_app/test_routes/test_main.py
@@ -1,15 +1,18 @@
 import unittest
 from types import SimpleNamespace
 
-from app.projects.repository_standards.routes.main import aggregate_owner_counts
+from app.projects.repository_standards.services.repository_compliance_service import (
+    RepositoryComplianceService,
+)
 
 
 class TestAggregateOwnerCounts(unittest.TestCase):
     def test_aggregates_counts_by_owner_and_maturity(self):
+        service = RepositoryComplianceService(asset_service=SimpleNamespace())
         entities = [
-            SimpleNamespace(id="team-a", name="Team A"),
-            SimpleNamespace(id="team-b", name="Team B"),
-            SimpleNamespace(id="team-c", name="Team C"),
+            SimpleNamespace(id="team-a", name="Team A", type=SimpleNamespace(name="TEAM")),
+            SimpleNamespace(id="team-b", name="Team B", type=SimpleNamespace(name="TEAM")),
+            SimpleNamespace(id="team-c", name="Team C", type=SimpleNamespace(name="TEAM")),
         ]
 
         repositories = [
@@ -31,11 +34,9 @@ class TestAggregateOwnerCounts(unittest.TestCase):
             ),
         ]
 
-        result = aggregate_owner_counts(
-            entities,
-            repositories,
-            "authoritative_team_owners",
-        )
+        service.get_all_repositories = lambda: repositories
+
+        result = service.aggregate_owner_counts(entities)
 
         self.assertEqual(
             result["team-a"],
@@ -66,7 +67,14 @@ class TestAggregateOwnerCounts(unittest.TestCase):
         )
 
     def test_supports_different_owner_field_names(self):
-        entities = [SimpleNamespace(id="bu-a", name="Business Unit A")]
+        service = RepositoryComplianceService(asset_service=SimpleNamespace())
+        entities = [
+            SimpleNamespace(
+                id="bu-a",
+                name="Business Unit A",
+                type=SimpleNamespace(name="BUSINESS_UNIT"),
+            )
+        ]
         repositories = [
             SimpleNamespace(
                 maturity_level=3,
@@ -74,11 +82,9 @@ class TestAggregateOwnerCounts(unittest.TestCase):
             )
         ]
 
-        result = aggregate_owner_counts(
-            entities,
-            repositories,
-            "authoritative_business_unit_owners",
-        )
+        service.get_all_repositories = lambda: repositories
+
+        result = service.aggregate_owner_counts(entities)
 
         self.assertEqual(
             result["bu-a"],


### PR DESCRIPTION
[Tracked in this ticket](https://github.com/ministryofjustice/github-community/issues/401)

Key updates:
This pull request makes several improvements and corrections to the repository standards compliance reporting feature. The most significant changes include fixing a number of spelling errors in variable and function names (standardizing on "authoritative" instead of "authorative"), adding a new service method to aggregate compliance statistics for owners, and updating the UI to use these new statistics and display them more consistently. There are also minor improvements to error messages and template rendering.

**Key changes:**

### Refactoring and Naming Consistency

* Renamed all instances of `authorative` to `authoritative` in variable names, function names, and model fields to improve code clarity and consistency across the codebase. This affects both backend logic and template rendering. [[1]](diffhunk://#diff-f183cdef0301a33b2538b7b7c9a5b3047631301259e87a39d0eb55337652cb66L21-R22) [[2]](diffhunk://#diff-e0e20f1d1be5de9e78f0ca5e224b6c907bfebe85d2114b91036bb9372e205c99R24-R57) [[3]](diffhunk://#diff-e0e20f1d1be5de9e78f0ca5e224b6c907bfebe85d2114b91036bb9372e205c99L77-R135) [[4]](diffhunk://#diff-925d69eb490cf92a2202a8cad404ea15f1e02716f4838991e85203a3af3a6ba7L154-R159) [[5]](diffhunk://#diff-925d69eb490cf92a2202a8cad404ea15f1e02716f4838991e85203a3af3a6ba7L194-R194) [[6]](diffhunk://#diff-925d69eb490cf92a2202a8cad404ea15f1e02716f4838991e85203a3af3a6ba7L204-R204) [[7]](diffhunk://#diff-508439d74a3ff1eb02e56f4787ac4527634b7b484f2f4e642e84a06b05deb379L81-R88) [[8]](diffhunk://#diff-508439d74a3ff1eb02e56f4787ac4527634b7b484f2f4e642e84a06b05deb379L125-R138) [[9]](diffhunk://#diff-508439d74a3ff1eb02e56f4787ac4527634b7b484f2f4e642e84a06b05deb379L247-R260) [[10]](diffhunk://#diff-c8cbfa0282ee750b4f20cc229c37176e663d63f012d34ff01c1fc6811d636f58L114-R88) [[11]](diffhunk://#diff-4b3b14f6af7f17fe7a9dde5292d7262c578ac4868f7b52969f65c18560099b78L33-R37)

* Corrected spelling mistakes in user-facing strings and error messages (e.g., "Imporves" → "Improves", "conifig" → "config", "Atleast" → "At Least"). [[1]](diffhunk://#diff-925d69eb490cf92a2202a8cad404ea15f1e02716f4838991e85203a3af3a6ba7L27-R27) [[2]](diffhunk://#diff-925d69eb490cf92a2202a8cad404ea15f1e02716f4838991e85203a3af3a6ba7L136-R136) [[3]](diffhunk://#diff-4fbe37934a178976b6f16031a62c4ed8c3e5fe6626c463ed1a166828d6e9ec57L34-R34)

### Compliance Statistics Aggregation

* Added a new `aggregate_owner_counts` method to `RepositoryComplianceService` that calculates repository counts and compliance levels (baseline, standard, exemplar) for each owner (business unit or team). This enables more informative summary statistics in the UI. [[1]](diffhunk://#diff-e0e20f1d1be5de9e78f0ca5e224b6c907bfebe85d2114b91036bb9372e205c99L1-R2) [[2]](diffhunk://#diff-e0e20f1d1be5de9e78f0ca5e224b6c907bfebe85d2114b91036bb9372e205c99R13) [[3]](diffhunk://#diff-e0e20f1d1be5de9e78f0ca5e224b6c907bfebe85d2114b91036bb9372e205c99R24-R57) [[4]](diffhunk://#diff-e0e20f1d1be5de9e78f0ca5e224b6c907bfebe85d2114b91036bb9372e205c99L77-R135)

* Updated the `/business-units` and `/teams` routes to use the new aggregation method and pass the resulting statistics to templates for display. [[1]](diffhunk://#diff-508439d74a3ff1eb02e56f4787ac4527634b7b484f2f4e642e84a06b05deb379R59-R70) [[2]](diffhunk://#diff-508439d74a3ff1eb02e56f4787ac4527634b7b484f2f4e642e84a06b05deb379R110-R121)

### UI Improvements

* Updated the business unit summary template to use a new `compliance_tag` macro for consistent rendering of compliance statistics, improving maintainability and visual consistency. [[1]](diffhunk://#diff-c8cbfa0282ee750b4f20cc229c37176e663d63f012d34ff01c1fc6811d636f58R2) [[2]](diffhunk://#diff-c8cbfa0282ee750b4f20cc229c37176e663d63f012d34ff01c1fc6811d636f58L32-R49)

* Updated the business units template to import new macros for compliance display and sorting.

### Minor Improvements

* Added small formatting and whitespace fixes in route files for clarity. [[1]](diffhunk://#diff-508439d74a3ff1eb02e56f4787ac4527634b7b484f2f4e642e84a06b05deb379R25) [[2]](diffhunk://#diff-508439d74a3ff1eb02e56f4787ac4527634b7b484f2f4e642e84a06b05deb379L143)