### PR TITLE
♻️ Update `Platforms` to `Office of the CTO`

### DIFF
--- a/migrations/versions/20260806T160211_repository_standards_update_platforms_config.py
+++ b/migrations/versions/20260806T160211_repository_standards_update_platforms_config.py
@@ -1,5 +1,4 @@
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/migrations/versions/20260806T160211_repository_standards_update_platforms_config.py
+++ b/migrations/versions/20260806T160211_repository_standards_update_platforms_config.py
@@ -1,0 +1,27 @@
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "64b771c789c0"
+down_revision = "5ecaf0b9197d"
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE owners
+        SET name = 'Office of the CTO', config ='{"name":"Office of the CTO", "teams":["office-of-the-cto", "platforms","hosting-migrations","aws-root-account-admin-team","webops","studio-webops","analytical-platform","data-engineering","analytics-hq","data-catalogue","data-platform","data-and-analytics-engineering","observability-platform"], "prefix":""}'::jsonb
+        WHERE name = 'Platforms'
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        UPDATE owners
+        SET name = 'Platforms', config ='{"name":"Platforms", "teams":["platforms","hosting-migrations","aws-root-account-admin-team","webops","studio-webops","analytical-platform","data-engineering","analytics-hq","data-catalogue","data-platform","data-and-analytics-engineering","observability-platform"], "prefix":""}'::jsonb
+        WHERE name = 'Office of the CTO'
+        """
+    )


### PR DESCRIPTION
## 👀 Purpose

- Related to https://mojdt.slack.com/archives/C05L0KBA7RS/p1786026079156549
- To ensure business units reflect current naming
- To ensure new repositories added to the OCTO team are assigned a business unit owner automatically


## ♻️ What's changed

- Updates `Platforms` Business to show as `Office of the CTO`
- Adds the `office-of-the-cto` GitHub Team to the `Office of the CTO` Business Unit

## 📝 Notes

- NA